### PR TITLE
ci: harden apt install for pandoc and protobuf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,13 @@ jobs:
           docker-images: true
           swap-storage: true
       - name: install pandoc
-        run: sudo apt-get install -y pandoc protobuf-compiler
+        shell: bash
+        run: |
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y --no-install-recommends pandoc protobuf-compiler || \
+          (sleep 5 && sudo apt-get update -o Acquire::Retries=3 && sudo apt-get install -y --no-install-recommends pandoc protobuf-compiler)
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI package installation commands to be more resilient; no production code changes.
> 
> **Overview**
> Improves the CI workflow’s `pandoc`/`protobuf-compiler` installation step by cleaning apt state, forcing an `apt-get update` with retries, using `--no-install-recommends`, and adding a fallback retry path on install failure to reduce transient apt flakes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d863d76e69d95dd5ce88e34efdebac347e88f50d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->