### PR TITLE
docs: add starter example and rust ecosystem integration guide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
     "crates/oris-runtime",
     "examples/vector_store_surrealdb",
+    "examples/oris_starter_axum",
 ]

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Common environment variables:
 ## Examples and docs
 
 - [Hello World graph](crates/oris-runtime/examples/graph_hello_world.rs)
+- [Starter service project (Axum)](examples/oris_starter_axum/README.md) — standalone workspace example for integrating Oris into a Rust backend.
 - [Durable agent job](crates/oris-runtime/examples/durable_agent_job.rs) — interrupt, restart, resume with same `thread_id`; state is checkpointed so it survives process restarts.
 - [Durable agent job with SQLite](crates/oris-runtime/examples/durable_agent_job_sqlite.rs) — same flow with SQLite persistence (run with `--features sqlite-persistence`).
 - [CLI durable job](crates/oris-runtime/examples/cli_durable_job.rs) — minimal operator CLI: `run`, `list`, `inspect`, `resume`, `replay`, `cancel` (requires `--features sqlite-persistence`).
@@ -275,6 +276,7 @@ Common environment variables:
 - [Persistence](crates/oris-runtime/examples/graph_persistence_basic.rs)
 - [Deep agent (planning + filesystem)](crates/oris-runtime/examples/deep_agent_basic.rs)
 - [Oris v1 OS architecture (single-tenant)](docs/oris-v1-os-architecture.md)
+- [Rust ecosystem integration guide](docs/rust-ecosystem-integration.md)
 
 Start the execution server:
 

--- a/docs/rust-ecosystem-integration.md
+++ b/docs/rust-ecosystem-integration.md
@@ -1,0 +1,75 @@
+# Oris + Rust Ecosystem Integration Guide
+
+This guide explains how to integrate Oris into common Rust stacks and how downstream users can adopt it safely.
+
+## Integration principles
+
+- Keep Oris execution contracts explicit (`thread_id`, idempotency keys, resume semantics).
+- Treat persistence and replay as first-class concerns, not optional afterthoughts.
+- Separate control-plane APIs (operators) from business APIs.
+- Use structured logging and tracing from day one.
+
+## Recommended integration patterns
+
+## 1) Web backends (Axum/Actix)
+
+- Use Oris runtime APIs behind authenticated service endpoints.
+- Expose a health endpoint and keep Oris routes under a versioned prefix.
+- Start from `examples/oris_starter_axum`.
+
+## 2) Async runtime (Tokio)
+
+- Run Oris inside Tokio services.
+- Avoid blocking calls in async handlers.
+- Use graceful shutdown to avoid interrupting in-flight work unexpectedly.
+
+## 3) Persistence
+
+- Local/dev:
+  - `sqlite-persistence` for quick durable workflows.
+- Production:
+  - Use stable persistence strategy and plan migration/backup from the start.
+  - Validate replay and recovery in CI.
+
+## 4) Observability (tracing ecosystem)
+
+- Use `tracing` and `tracing-subscriber` with request/run correlation IDs.
+- Emit structured fields for:
+  - `thread_id`/`run_id`
+  - `attempt_id`
+  - lease and interrupt identifiers
+- Add metrics and traces before scaling worker concurrency.
+
+## 5) CLI and operator tooling
+
+- Pair service APIs with an operator CLI.
+- Ensure CLI commands map one-to-one with API contracts:
+  - run/list/inspect/resume/replay/cancel
+
+## 6) Testing strategy
+
+- Unit tests for reducers/state transitions.
+- API tests for idempotency and conflict semantics.
+- Crash/failover tests for checkpoint recovery and lease expiry.
+
+## Adoption path for external users
+
+1. Start with a single service and SQLite persistence.
+2. Implement one business workflow graph end-to-end.
+3. Add interrupt + resume flow with operator visibility.
+4. Add replay and failover validation in CI.
+5. Harden auth/security and observability before production rollout.
+
+## Reference entry points
+
+- Runtime examples: `crates/oris-runtime/examples/`
+- Starter project: `examples/oris_starter_axum`
+- Durable execution docs: `docs/durable-execution.md`
+- Kernel contract docs: `docs/kernel-api.md`
+
+## Common mistakes to avoid
+
+- Treating `thread_id` as optional/non-stable.
+- Missing idempotency for run and step reporting.
+- Skipping replay/recovery tests until late stages.
+- Coupling business API errors with operator control-plane behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Example Projects
+
+This directory contains standalone workspace example projects (separate from `crates/oris-runtime/examples`).
+
+## Projects
+
+- `oris_starter_axum`:
+  - Starter service template for integrating Oris runtime into an Axum backend.
+  - Includes durable execution endpoints and health checks.
+- `vector_store_surrealdb`:
+  - Example integration with SurrealDB vector store.
+
+## Run
+
+From repository root:
+
+```bash
+cargo run -p oris_starter_axum
+cargo run -p vector_store_surrealdb
+```

--- a/examples/oris_starter_axum/Cargo.toml
+++ b/examples/oris_starter_axum/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oris_starter_axum"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.81"
+axum = "0.7"
+oris-runtime = { path = "../../crates/oris-runtime", features = ["sqlite-persistence", "execution-server"] }
+serde_json = "1.0"
+tokio = { version = "1.36.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/examples/oris_starter_axum/README.md
+++ b/examples/oris_starter_axum/README.md
@@ -1,0 +1,57 @@
+# Oris Starter (Axum)
+
+This is a starter service project that shows how to use Oris as part of a Rust web backend.
+
+## What this example demonstrates
+
+- Running Oris runtime inside an Axum HTTP service.
+- SQLite-backed durable execution and idempotency.
+- Operator-facing endpoints for run/list/inspect/resume/replay/cancel.
+- Basic health endpoint and tracing setup.
+
+## Run
+
+From repository root:
+
+```bash
+cargo run -p oris_starter_axum
+```
+
+Optional environment variables:
+
+- `ORIS_SERVER_ADDR` (default: `127.0.0.1:8080`)
+- `ORIS_SQLITE_DB` (default: `oris_starter.db`)
+
+## Quick API smoke test
+
+Create a run:
+
+```bash
+curl -s -X POST http://127.0.0.1:8080/v1/jobs \
+  -H 'content-type: application/json' \
+  -d '{"thread_id":"starter-1","input":"hello from starter","idempotency_key":"starter-key-1"}'
+```
+
+Inspect run:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/jobs/starter-1
+```
+
+List runs:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/jobs
+```
+
+## Where to go next
+
+- Add your own graph nodes and tool calls.
+- Integrate auth middleware for operator APIs.
+- Emit traces/metrics to your observability backend.
+- Replace SQLite with your production persistence strategy as needed.
+
+See also:
+
+- `docs/rust-ecosystem-integration.md`
+- `crates/oris-runtime/examples/`

--- a/examples/oris_starter_axum/src/main.rs
+++ b/examples/oris_starter_axum/src/main.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::routing::get;
+use axum::{Json, Router};
+use oris_runtime::graph::{function_node, MessagesState, SqliteSaver, StateGraph, END, START};
+use oris_runtime::kernel::{build_router, ExecutionApiState};
+use oris_runtime::schemas::messages::Message;
+use serde_json::json;
+use tracing_subscriber::EnvFilter;
+
+fn build_compiled(
+    db_path: &str,
+) -> Result<Arc<oris_runtime::graph::CompiledGraph<MessagesState>>> {
+    let research = function_node("research", |_state: &MessagesState| async move {
+        let mut update = HashMap::new();
+        update.insert(
+            "messages".to_string(),
+            serde_json::to_value(vec![Message::new_ai_message(
+                "starter workflow step completed",
+            )])?,
+        );
+        Ok(update)
+    });
+
+    let mut graph = StateGraph::<MessagesState>::new();
+    graph.add_node("research", research)?;
+    graph.add_edge(START, "research");
+    graph.add_edge("research", END);
+
+    let checkpointer = Arc::new(SqliteSaver::new(db_path)?);
+    let compiled = graph.compile_with_persistence(Some(checkpointer), None)?;
+    Ok(Arc::new(compiled))
+}
+
+async fn healthz() -> Json<serde_json::Value> {
+    Json(json!({ "status": "ok" }))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            EnvFilter::new("info,oris_runtime=info,oris_starter_axum=info")
+        }))
+        .init();
+
+    let db_path = std::env::var("ORIS_SQLITE_DB").unwrap_or_else(|_| "oris_starter.db".into());
+    let addr = std::env::var("ORIS_SERVER_ADDR").unwrap_or_else(|_| "127.0.0.1:8080".into());
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let compiled = build_compiled(&db_path)?;
+    let state = ExecutionApiState::with_sqlite_idempotency(compiled, &db_path);
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .merge(build_router(state));
+
+    tracing::info!("oris starter server listening on http://{}", addr);
+    axum::serve(listener, app).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Motivation and context

- Problem being solved:
- Why this approach:
- Alternatives considered (if relevant):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Documentation only
- [ ] Refactor / cleanup

## Validation

List commands run and results:

```bash
# example
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
```

## API / contract impact

- [ ] No public API change
- [ ] Public API changed (describe below)

If changed, include migration notes:

## Checklist

- [ ] Code follows project style
- [ ] Tests added/updated for changed behavior
- [ ] Docs/examples updated when behavior changed
- [ ] No secrets or private data added
- [ ] Linked issue(s) if applicable

## Related issue

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive docs and example code; main risk is workspace/build impact from adding a new example crate and enabling `execution-server` + `sqlite-persistence` features in that example.
> 
> **Overview**
> Adds a new standalone workspace example, `oris_starter_axum`, showing an Axum service that hosts the Oris execution-server router plus a `/healthz` endpoint, backed by SQLite checkpoints and idempotency.
> 
> Updates top-level docs to reference the starter and introduces a new `docs/rust-ecosystem-integration.md` guide plus an `examples/README.md` describing standalone example projects, and registers the new example crate in the workspace `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51b76fab76eb0e8dac9e0b13fbcfc69494aa9c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->