### PR TITLE
Fix EvoKernel lifecycle replay semantics and release v0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolu
 ```
 
 What exists today: proposal-driven capture, sandboxed validation, JSONL evolution storage, and replay-first reuse.
-Use `replay_or_fallback_for_run` when you want an explicit replay audit id; `replay_or_fallback` still works and auto-generates one.
+Use `replay_or_fallback_for_run` when you want an explicit replay audit id; it records `CapsuleReused.replay_run_id` while preserving the capsule's original `run_id`. `replay_or_fallback` still works and auto-generates one.
 What is still design-target only: always-on autonomous dev loops, issue intake, and automatic branch/release orchestration.
 
 - [EvoKernel docs index](docs/evokernel/README.md)

--- a/RELEASE_v0.13.1.md
+++ b/RELEASE_v0.13.1.md
@@ -1,0 +1,30 @@
+# v0.13.1 - EvoKernel lifecycle replay fixes
+
+`oris-runtime` now ships the EvoKernel lifecycle audit fixes so remote replay assets, replay attribution, and compatibility behavior stay consistent in production paths.
+
+## What's in this release
+
+- Fixed remote Evo asset sharing so exported and fetched promoted assets include the mutation payload required for first local replay.
+- Preserved replay compatibility by restoring the legacy `ReplayExecutor` entrypoint while recording explicit replay execution IDs separately in Evo events.
+
+## Validation
+
+- cargo fmt --all -- --check
+- ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo build --verbose --all --release --all-features
+- cargo test -p oris-evolution --lib
+- cargo test -p oris-evokernel --lib
+- cargo test -p oris-evokernel --test evolution_lifecycle_regression
+- cargo test -p oris-runtime --lib execution_server::api_handlers::tests::evolution_publish_fetch_and_revoke_routes_work
+- ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo test --release --all-features
+- cargo publish -p oris-evolution --dry-run --registry crates-io
+- cargo publish -p oris-evolution --registry crates-io
+- cargo publish -p oris-evokernel --dry-run --registry crates-io
+- cargo publish -p oris-evokernel --registry crates-io
+- ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo publish -p oris-runtime --all-features --dry-run --registry crates-io
+- ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo publish -p oris-runtime --all-features --registry crates-io
+
+## Links
+
+- Crate: https://crates.io/crates/oris-runtime
+- Docs: https://docs.rs/oris-runtime
+- Repo: https://github.com/Colin4k1024/Oris

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -12,7 +12,7 @@ async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
 oris-agent-contract = { version = "0.2.0", path = "../oris-agent-contract" }
 oris-economics = { version = "0.1.1", path = "../oris-economics" }
-oris-evolution = { version = "0.2.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.2.1", path = "../oris-evolution" }
 oris-evolution-network = { version = "0.2.0", path = "../oris-evolution-network" }
 oris-governor = { version = "0.3.0", path = "../oris-governor" }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -677,11 +677,21 @@ pub enum ReplayError {
 pub trait ReplayExecutor: Send + Sync {
     async fn try_replay(
         &self,
-        run_id: &RunId,
         input: &SelectorInput,
         policy: &SandboxPolicy,
         validation: &ValidationPlan,
     ) -> Result<ReplayDecision, ReplayError>;
+
+    async fn try_replay_for_run(
+        &self,
+        run_id: &RunId,
+        input: &SelectorInput,
+        policy: &SandboxPolicy,
+        validation: &ValidationPlan,
+    ) -> Result<ReplayDecision, ReplayError> {
+        let _ = run_id;
+        self.try_replay(input, policy, validation).await
+    }
 }
 
 pub struct StoreReplayExecutor {
@@ -699,7 +709,29 @@ pub struct StoreReplayExecutor {
 impl ReplayExecutor for StoreReplayExecutor {
     async fn try_replay(
         &self,
+        input: &SelectorInput,
+        policy: &SandboxPolicy,
+        validation: &ValidationPlan,
+    ) -> Result<ReplayDecision, ReplayError> {
+        self.try_replay_inner(None, input, policy, validation).await
+    }
+
+    async fn try_replay_for_run(
+        &self,
         run_id: &RunId,
+        input: &SelectorInput,
+        policy: &SandboxPolicy,
+        validation: &ValidationPlan,
+    ) -> Result<ReplayDecision, ReplayError> {
+        self.try_replay_inner(Some(run_id), input, policy, validation)
+            .await
+    }
+}
+
+impl StoreReplayExecutor {
+    async fn try_replay_inner(
+        &self,
+        replay_run_id: Option<&RunId>,
         input: &SelectorInput,
         policy: &SandboxPolicy,
         validation: &ValidationPlan,
@@ -831,7 +863,8 @@ impl ReplayExecutor for StoreReplayExecutor {
             .append_event(EvolutionEvent::CapsuleReused {
                 capsule_id: capsule.id.clone(),
                 gene_id: capsule.gene_id.clone(),
-                run_id: run_id.clone(),
+                run_id: capsule.run_id.clone(),
+                replay_run_id: replay_run_id.cloned(),
             })
             .map_err(|err| ReplayError::Store(err.to_string()))?;
         self.record_reuse_settlement(remote_publisher.as_deref(), true);
@@ -841,15 +874,13 @@ impl ReplayExecutor for StoreReplayExecutor {
             capsule_id: Some(capsule.id),
             fallback_to_planner: false,
             reason: if exact_match {
-                "replayed via exact-match cold-start lookup".into()
+                "replayed via cold-start lookup".into()
             } else {
                 "replayed via selector".into()
             },
         })
     }
-}
 
-impl StoreReplayExecutor {
     fn rerank_with_reputation_bias(&self, candidates: &mut [GeneCandidate]) {
         let Some(ledger) = self.economics.as_ref() else {
             return;
@@ -1608,7 +1639,7 @@ impl<S: KernelState> EvoKernel<S> {
             stake_policy: self.stake_policy.clone(),
         };
         executor
-            .try_replay(run_id, &input, &self.sandbox_policy, &self.validation_plan)
+            .try_replay_for_run(run_id, &input, &self.sandbox_policy, &self.validation_plan)
             .await
             .map_err(|err| EvoKernelError::Validation(err.to_string()))
     }
@@ -2171,11 +2202,14 @@ fn quarantined_remote_exact_match_candidates(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let signal_set = input
+    let normalized_signals = input
         .signals
         .iter()
-        .map(|signal| signal.to_ascii_lowercase())
-        .collect::<BTreeSet<_>>();
+        .filter_map(|signal| normalize_signal_phrase(signal))
+        .collect::<Vec<_>>();
+    if normalized_signals.is_empty() {
+        return Vec::new();
+    }
     let mut candidates = projection
         .genes
         .into_iter()
@@ -2196,48 +2230,57 @@ fn quarantined_remote_exact_match_candidates(
                     return None;
                 }
             }
-            let gene_signals = gene
+            let matched_signal_count = gene
                 .signals
                 .iter()
-                .map(|signal| signal.to_ascii_lowercase())
-                .collect::<BTreeSet<_>>();
-            if gene_signals == signal_set {
-                let mut matched_capsules = capsules
-                    .iter()
-                    .filter(|capsule| {
-                        capsule.gene_id == gene.id
-                            && capsule.state == AssetState::Quarantined
-                            && remote_asset_ids.contains(&capsule.id)
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>();
-                matched_capsules.sort_by(|left, right| {
-                    replay_environment_match_factor(&input.env, &right.env)
-                        .partial_cmp(&replay_environment_match_factor(&input.env, &left.env))
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                        .then_with(|| {
-                            right
-                                .confidence
-                                .partial_cmp(&left.confidence)
-                                .unwrap_or(std::cmp::Ordering::Equal)
+                .filter(|candidate| {
+                    normalize_signal_phrase(candidate)
+                        .map(|candidate| {
+                            normalized_signals.iter().any(|signal| {
+                                candidate.contains(signal) || signal.contains(&candidate)
+                            })
                         })
-                        .then_with(|| left.id.cmp(&right.id))
-                });
-                if matched_capsules.is_empty() {
-                    None
-                } else {
-                    let score = matched_capsules
-                        .first()
-                        .map(|capsule| replay_environment_match_factor(&input.env, &capsule.env))
-                        .unwrap_or(0.0);
-                    Some(GeneCandidate {
-                        gene,
-                        score,
-                        capsules: matched_capsules,
+                        .unwrap_or(false)
+                })
+                .count();
+            if matched_signal_count == 0 {
+                return None;
+            }
+
+            let mut matched_capsules = capsules
+                .iter()
+                .filter(|capsule| {
+                    capsule.gene_id == gene.id
+                        && capsule.state == AssetState::Quarantined
+                        && remote_asset_ids.contains(&capsule.id)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            matched_capsules.sort_by(|left, right| {
+                replay_environment_match_factor(&input.env, &right.env)
+                    .partial_cmp(&replay_environment_match_factor(&input.env, &left.env))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| {
+                        right
+                            .confidence
+                            .partial_cmp(&left.confidence)
+                            .unwrap_or(std::cmp::Ordering::Equal)
                     })
-                }
-            } else {
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            if matched_capsules.is_empty() {
                 None
+            } else {
+                let overlap = matched_signal_count as f32 / normalized_signals.len() as f32;
+                let env_score = matched_capsules
+                    .first()
+                    .map(|capsule| replay_environment_match_factor(&input.env, &capsule.env))
+                    .unwrap_or(0.0);
+                Some(GeneCandidate {
+                    gene,
+                    score: overlap.max(env_score),
+                    capsules: matched_capsules,
+                })
             }
         })
         .collect::<Vec<_>>();
@@ -2287,22 +2330,78 @@ fn export_promoted_assets_from_store(
     sender_id: impl Into<String>,
 ) -> Result<EvolutionEnvelope, EvoKernelError> {
     let projection = store.rebuild_projection().map_err(store_err)?;
-    let mut assets = Vec::new();
-    for gene in projection
+    let genes = projection
         .genes
         .into_iter()
         .filter(|gene| gene.state == AssetState::Promoted)
-    {
-        assets.push(NetworkAsset::Gene { gene });
-    }
-    for capsule in projection
+        .collect::<Vec<_>>();
+    let capsules = projection
         .capsules
         .into_iter()
         .filter(|capsule| capsule.state == AssetState::Promoted)
-    {
+        .collect::<Vec<_>>();
+    let assets = replay_export_assets(store, genes, capsules)?;
+    Ok(EvolutionEnvelope::publish(sender_id, assets))
+}
+
+fn replay_export_assets(
+    store: &dyn EvolutionStore,
+    genes: Vec<Gene>,
+    capsules: Vec<Capsule>,
+) -> Result<Vec<NetworkAsset>, EvoKernelError> {
+    let mutation_ids = capsules
+        .iter()
+        .map(|capsule| capsule.mutation_id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut assets = replay_export_events_for_mutations(store, &mutation_ids)?;
+    for gene in genes {
+        assets.push(NetworkAsset::Gene { gene });
+    }
+    for capsule in capsules {
         assets.push(NetworkAsset::Capsule { capsule });
     }
-    Ok(EvolutionEnvelope::publish(sender_id, assets))
+    Ok(assets)
+}
+
+fn replay_export_events_for_mutations(
+    store: &dyn EvolutionStore,
+    mutation_ids: &BTreeSet<String>,
+) -> Result<Vec<NetworkAsset>, EvoKernelError> {
+    if mutation_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut assets = Vec::new();
+    let mut seen_mutations = BTreeSet::new();
+    let mut seen_spec_links = BTreeSet::new();
+    for stored in store.scan(1).map_err(store_err)? {
+        match stored.event {
+            EvolutionEvent::MutationDeclared { mutation }
+                if mutation_ids.contains(&mutation.intent.id)
+                    && seen_mutations.insert(mutation.intent.id.clone()) =>
+            {
+                assets.push(NetworkAsset::EvolutionEvent {
+                    event: EvolutionEvent::MutationDeclared { mutation },
+                });
+            }
+            EvolutionEvent::SpecLinked {
+                mutation_id,
+                spec_id,
+            } if mutation_ids.contains(&mutation_id)
+                && seen_spec_links.insert((mutation_id.clone(), spec_id.clone())) =>
+            {
+                assets.push(NetworkAsset::EvolutionEvent {
+                    event: EvolutionEvent::SpecLinked {
+                        mutation_id,
+                        spec_id,
+                    },
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(assets)
 }
 
 fn import_remote_envelope_into_store(
@@ -2449,13 +2548,7 @@ fn fetch_assets_from_store(
         .filter(|capsule| matched_gene_ids.contains(&capsule.gene_id))
         .collect();
 
-    let mut assets = Vec::new();
-    for gene in matched_genes {
-        assets.push(NetworkAsset::Gene { gene });
-    }
-    for capsule in matched_capsules {
-        assets.push(NetworkAsset::Capsule { capsule });
-    }
+    let assets = replay_export_assets(store, matched_genes, matched_capsules)?;
 
     Ok(FetchResponse {
         sender_id: responder_id.into(),
@@ -3317,7 +3410,51 @@ index 0000000..1111111
         assert_eq!(decision.capsule_id, Some(capsule.id));
         assert!(store.scan(1).unwrap().iter().any(|stored| matches!(
             &stored.event,
-            EvolutionEvent::CapsuleReused { run_id, .. } if run_id == &replay_run_id
+            EvolutionEvent::CapsuleReused {
+                run_id,
+                replay_run_id: Some(current_replay_run_id),
+                ..
+            } if run_id == "run-2" && current_replay_run_id == &replay_run_id
+        )));
+    }
+
+    #[tokio::test]
+    async fn legacy_replay_executor_api_preserves_original_capsule_run_id() {
+        let capture_run_id = "run-legacy-capture".to_string();
+        let (evo, store) = build_test_evo("replay-legacy", &capture_run_id, command_validator());
+        let capsule = evo
+            .capture_successful_mutation(&capture_run_id, sample_mutation())
+            .await
+            .unwrap();
+        let executor = StoreReplayExecutor {
+            sandbox: evo.sandbox.clone(),
+            validator: evo.validator.clone(),
+            store: evo.store.clone(),
+            selector: evo.selector.clone(),
+            governor: evo.governor.clone(),
+            economics: Some(evo.economics.clone()),
+            remote_publishers: Some(evo.remote_publishers.clone()),
+            stake_policy: evo.stake_policy.clone(),
+        };
+
+        let decision = executor
+            .try_replay(
+                &replay_input("missing readme"),
+                &evo.sandbox_policy,
+                &evo.validation_plan,
+            )
+            .await
+            .unwrap();
+
+        assert!(decision.used_capsule);
+        assert_eq!(decision.capsule_id, Some(capsule.id));
+        assert!(store.scan(1).unwrap().iter().any(|stored| matches!(
+            &stored.event,
+            EvolutionEvent::CapsuleReused {
+                run_id,
+                replay_run_id: None,
+                ..
+            } if run_id == &capture_run_id
         )));
     }
 
@@ -3465,7 +3602,87 @@ index 0000000..1111111
         assert_eq!(released_capsule.state, AssetState::Promoted);
         let exported_after_replay =
             export_promoted_assets_from_store(store.as_ref(), "node-local").unwrap();
-        assert_eq!(exported_after_replay.assets.len(), 2);
+        assert_eq!(exported_after_replay.assets.len(), 3);
+        assert!(exported_after_replay.assets.iter().any(|asset| matches!(
+            asset,
+            NetworkAsset::EvolutionEvent {
+                event: EvolutionEvent::MutationDeclared { .. }
+            }
+        )));
+    }
+
+    #[tokio::test]
+    async fn publish_local_assets_include_mutation_payload_for_remote_replay() {
+        let (source, source_store) = build_test_evo(
+            "remote-publish-export",
+            "run-remote-publish-export",
+            command_validator(),
+        );
+        source
+            .capture_successful_mutation(&"run-remote-publish-export".into(), sample_mutation())
+            .await
+            .unwrap();
+        let envelope = EvolutionNetworkNode::new(source_store.clone())
+            .publish_local_assets("node-source")
+            .unwrap();
+        assert!(envelope.assets.iter().any(|asset| matches!(
+            asset,
+            NetworkAsset::EvolutionEvent {
+                event: EvolutionEvent::MutationDeclared { mutation }
+            } if mutation.intent.id == "mutation-1"
+        )));
+
+        let (remote, _) = build_test_evo(
+            "remote-publish-import",
+            "run-remote-publish-import",
+            command_validator(),
+        );
+        remote.import_remote_envelope(&envelope).unwrap();
+
+        let decision = remote
+            .replay_or_fallback(replay_input("missing readme"))
+            .await
+            .unwrap();
+
+        assert!(decision.used_capsule);
+        assert!(!decision.fallback_to_planner);
+    }
+
+    #[tokio::test]
+    async fn fetch_assets_include_mutation_payload_for_remote_replay() {
+        let (evo, store) = build_test_evo(
+            "remote-fetch-export",
+            "run-remote-fetch",
+            command_validator(),
+        );
+        evo.capture_successful_mutation(&"run-remote-fetch".into(), sample_mutation())
+            .await
+            .unwrap();
+
+        let response = EvolutionNetworkNode::new(store.clone())
+            .fetch_assets(
+                "node-source",
+                &FetchQuery {
+                    sender_id: "node-client".into(),
+                    signals: vec!["missing readme".into()],
+                },
+            )
+            .unwrap();
+
+        assert!(response.assets.iter().any(|asset| matches!(
+            asset,
+            NetworkAsset::EvolutionEvent {
+                event: EvolutionEvent::MutationDeclared { mutation }
+            } if mutation.intent.id == "mutation-1"
+        )));
+        assert!(response
+            .assets
+            .iter()
+            .any(|asset| matches!(asset, NetworkAsset::Gene { .. })));
+        assert!(response
+            .assets
+            .iter()
+            .any(|asset| matches!(asset, NetworkAsset::Capsule { .. })));
     }
 
     #[test]

--- a/crates/oris-evolution/Cargo.toml
+++ b/crates/oris-evolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evolution"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-evolution/src/core.rs
+++ b/crates/oris-evolution/src/core.rs
@@ -183,6 +183,8 @@ pub enum EvolutionEvent {
         capsule_id: CapsuleId,
         gene_id: GeneId,
         run_id: RunId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        replay_run_id: Option<RunId>,
     },
     GeneProjected {
         gene: Gene,
@@ -1272,5 +1274,38 @@ mod tests {
         assert_eq!(selected[0].gene.id, "gene-a");
         assert_eq!(selected[0].capsules[0].id, "capsule-a-best");
         assert!(selected[0].score > selected[1].score);
+    }
+
+    #[test]
+    fn legacy_capsule_reused_events_deserialize_without_replay_run_id() {
+        let serialized = r#"{
+  "seq": 1,
+  "timestamp": "2026-03-04T00:00:00Z",
+  "prev_hash": "",
+  "record_hash": "hash",
+  "event": {
+    "kind": "capsule_reused",
+    "capsule_id": "capsule-1",
+    "gene_id": "gene-1",
+    "run_id": "run-1"
+  }
+}"#;
+
+        let stored = serde_json::from_str::<StoredEvolutionEvent>(serialized).unwrap();
+
+        match stored.event {
+            EvolutionEvent::CapsuleReused {
+                capsule_id,
+                gene_id,
+                run_id,
+                replay_run_id,
+            } => {
+                assert_eq!(capsule_id, "capsule-1");
+                assert_eq!(gene_id, "gene-1");
+                assert_eq!(run_id, "run-1");
+                assert_eq!(replay_run_id, None);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 }

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.13", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.6.0", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.6.1", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/src/execution_server/api_handlers.rs
+++ b/crates/oris-runtime/src/execution_server/api_handlers.rs
@@ -3379,9 +3379,10 @@ mod tests {
         let fetch_json: serde_json::Value =
             serde_json::from_slice(&fetch_body).expect("fetch json");
         assert_eq!(fetch_json["data"]["sender_id"], "execution-api");
+        // Remotely published genes stay quarantined until a successful local replay promotes them.
         assert_eq!(
             fetch_json["data"]["assets"].as_array().map(Vec::len),
-            Some(1)
+            Some(0)
         );
 
         let revoke_req = Request::builder()

--- a/docs/evokernel/evolution.md
+++ b/docs/evokernel/evolution.md
@@ -159,7 +159,8 @@ If replay succeeds, LLM reasoning is skipped.
 
 When the caller needs the reuse event tied to a specific execution, use
 `replay_or_fallback_for_run(...)` so the resulting `CapsuleReused` event carries
-that replay run id explicitly.
+that replay run id in `replay_run_id` while preserving the capsule's original
+`run_id`.
 
 ## 9. Evolution Store Requirements
 

--- a/examples/evo_oris_repo/README.md
+++ b/examples/evo_oris_repo/README.md
@@ -22,7 +22,7 @@ The example wires:
 - `JsonlEvolutionStore`
 - `DefaultGovernor`
 
-The example uses an explicit replay run id so `CapsuleReused` events stay attributable to the current replay execution.
+The example uses an explicit replay run id so `CapsuleReused.replay_run_id` stays attributable to the current replay execution while preserving the original capsule run id.
 
 ## Run
 


### PR DESCRIPTION
## Summary

Ship the EvoKernel lifecycle audit follow-up as a released patch set, including remote replay asset fixes, replay attribution compatibility, and the final API test alignment for quarantined remote genes.

## Motivation and context

- Problem being solved:
  - Remote shared Evo assets were missing replay-required mutation payloads in real export/fetch paths.
  - `CapsuleReused.run_id` semantics had drifted without a schema change.
  - `ReplayExecutor` had a compatibility break for external implementers.
  - The execution server API test still assumed remotely published genes were immediately fetchable before first successful local replay.
- Why this approach:
  - Preserve backward compatibility while making the production replay path carry the required assets and explicit replay attribution.
  - Keep remote imports quarantined until local replay promotes them, matching the intended lifecycle model.
  - Release the dependent crate chain (`oris-evolution`, `oris-evokernel`, `oris-runtime`) together so crates.io consumers receive the full fix set.
- Alternatives considered (if relevant):
  - Keeping the direct trait signature break or overloading old event fields would have left downstream consumers with silent compatibility risk.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Documentation only
- [ ] Refactor / cleanup

## Validation

List commands run and results:

```bash
cargo fmt --all -- --check
ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo build --verbose --all --release --all-features
cargo test -p oris-evolution --lib
cargo test -p oris-evokernel --lib
cargo test -p oris-evokernel --test evolution_lifecycle_regression
cargo test -p oris-runtime --lib execution_server::api_handlers::tests::evolution_publish_fetch_and_revoke_routes_work
ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo test --release --all-features
cargo publish -p oris-evolution --dry-run --registry crates-io
cargo publish -p oris-evolution --registry crates-io
cargo publish -p oris-evokernel --dry-run --registry crates-io
cargo publish -p oris-evokernel --registry crates-io
ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo publish -p oris-runtime --all-features --dry-run --registry crates-io
ORT_LIB_LOCATION=/Users/jiafan/onnxruntime ORT_PREFER_DYNAMIC_LINK=0 cargo publish -p oris-runtime --all-features --registry crates-io
```

## API / contract impact

- [ ] No public API change
- [x] Public API changed (describe below)

If changed, include migration notes:
- `ReplayExecutor` keeps the legacy `try_replay(...)` entrypoint and adds `try_replay_for_run(...)` with a default implementation, so existing implementers remain source-compatible.
- `CapsuleReused` now adds optional `replay_run_id` while preserving the original `run_id` meaning.

## Checklist

- [x] Code follows project style
- [x] Tests added/updated for changed behavior
- [x] Docs/examples updated when behavior changed
- [x] No secrets or private data added
- [x] Linked issue(s) if applicable

## Related issue

Closes #82

## Release notes

- Published `oris-evolution v0.2.1`
- Published `oris-evokernel v0.6.1`
- Published `oris-runtime v0.13.1`
- Pushed tag `v0.13.1`