### PR TITLE
[EVO26-W6-07][P1] 官方经验复用质量门禁一致性（Test/Example 共享语义）

### DIFF
--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -169,6 +169,116 @@ const SHADOW_PROMOTION_MIN_DECAYED_CONFIDENCE: f32 = MIN_REPLAY_CONFIDENCE;
 const REPLAY_REASONING_TOKEN_FLOOR: u64 = 192;
 const REPLAY_REASONING_TOKEN_SIGNAL_WEIGHT: u64 = 24;
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepairQualityGateReport {
+    pub root_cause: bool,
+    pub fix: bool,
+    pub verification: bool,
+    pub rollback: bool,
+    pub incident_anchor: bool,
+    pub structure_score: usize,
+    pub has_actionable_command: bool,
+}
+
+impl RepairQualityGateReport {
+    pub fn passes(&self) -> bool {
+        self.incident_anchor
+            && self.structure_score >= 3
+            && (self.has_actionable_command || self.verification)
+    }
+
+    pub fn failed_checks(&self) -> Vec<String> {
+        let mut failed = Vec::new();
+        if !self.incident_anchor {
+            failed.push("包含unknown command故障上下文".to_string());
+        }
+        if self.structure_score < 3 {
+            failed.push("结构化修复信息至少满足3项（根因/修复/验证/回滚）".to_string());
+        }
+        if !(self.has_actionable_command || self.verification) {
+            failed.push("包含可执行验证命令或验证计划".to_string());
+        }
+        failed
+    }
+}
+
+pub fn evaluate_repair_quality_gate(plan: &str) -> RepairQualityGateReport {
+    fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+        needles.iter().any(|needle| haystack.contains(needle))
+    }
+
+    let lower = plan.to_ascii_lowercase();
+    let root_cause = contains_any(
+        plan,
+        &["根因", "原因分析", "问题定位", "原因定位", "根本原因"],
+    ) || contains_any(
+        &lower,
+        &[
+            "root cause",
+            "cause analysis",
+            "problem diagnosis",
+            "diagnosis",
+        ],
+    );
+    let fix = contains_any(
+        plan,
+        &["修复步骤", "修复方案", "处理步骤", "修复建议", "整改方案"],
+    ) || contains_any(
+        &lower,
+        &[
+            "fix",
+            "remediation",
+            "mitigation",
+            "resolution",
+            "repair steps",
+        ],
+    );
+    let verification = contains_any(
+        plan,
+        &["验证命令", "验证步骤", "回归测试", "验证方式", "验收步骤"],
+    ) || contains_any(
+        &lower,
+        &[
+            "verification",
+            "validate",
+            "regression test",
+            "smoke test",
+            "test command",
+        ],
+    );
+    let rollback = contains_any(plan, &["回滚方案", "回滚步骤", "恢复方案", "撤销方案"])
+        || contains_any(&lower, &["rollback", "revert", "fallback plan", "undo"]);
+    let incident_anchor = contains_any(
+        &lower,
+        &[
+            "unknown command",
+            "process",
+            "proccess",
+            "command not found",
+        ],
+    ) || contains_any(plan, &["命令不存在", "命令未找到", "未知命令"]);
+    let structure_score = [root_cause, fix, verification, rollback]
+        .into_iter()
+        .filter(|ok| *ok)
+        .count();
+    let has_actionable_command = contains_any(
+        &lower,
+        &[
+            "cargo ", "git ", "python ", "pip ", "npm ", "pnpm ", "yarn ", "bash ", "make ",
+        ],
+    );
+
+    RepairQualityGateReport {
+        root_cause,
+        fix,
+        verification,
+        rollback,
+        incident_anchor,
+        structure_score,
+        has_actionable_command,
+    }
+}
+
 impl ValidationReport {
     pub fn to_snapshot(&self, profile: &str) -> ValidationSnapshot {
         ValidationSnapshot {
@@ -5436,6 +5546,35 @@ mod tests {
         fn version(&self) -> u32 {
             1
         }
+    }
+
+    #[test]
+    fn repair_quality_gate_accepts_semantic_variants() {
+        let plan = r#"
+根本原因：脚本中拼写错误导致 unknown command 'process'。
+修复建议：将 `proccess` 更正为 `process`，并统一命令入口。
+验证方式：执行 `cargo check -p oris-runtime` 与回归测试。
+恢复方案：若新入口异常，立即回滚到旧命令映射。
+"#;
+        let report = evaluate_repair_quality_gate(plan);
+        assert!(report.passes());
+        assert!(report.failed_checks().is_empty());
+    }
+
+    #[test]
+    fn repair_quality_gate_rejects_missing_incident_anchor() {
+        let plan = r#"
+原因分析：逻辑分支覆盖不足。
+修复方案：补充分支与日志。
+验证命令：cargo check -p oris-runtime
+回滚方案：git revert HEAD
+"#;
+        let report = evaluate_repair_quality_gate(plan);
+        assert!(!report.passes());
+        assert!(report
+            .failed_checks()
+            .iter()
+            .any(|check| check.contains("unknown command")));
     }
 
     fn temp_workspace(name: &str) -> std::path::PathBuf {

--- a/crates/oris-runtime/examples/agent_official_experience_reuse.rs
+++ b/crates/oris-runtime/examples/agent_official_experience_reuse.rs
@@ -24,9 +24,10 @@ use oris_runtime::agent::{create_agent_from_llm, UnifiedAgent};
 use oris_runtime::error::ToolError;
 #[cfg(feature = "full-evolution-experimental")]
 use oris_runtime::evolution::{
-    CommandValidator, EvoAssetState, EvoEvolutionStore as EvolutionStore, EvoKernel,
-    EvoSandboxPolicy as SandboxPolicy, EvoSelectorInput as SelectorInput, EvolutionNetworkNode,
-    FetchQuery, JsonlEvolutionStore, LocalProcessSandbox, ValidationPlan, ValidationStage,
+    evaluate_repair_quality_gate, CommandValidator, EvoAssetState,
+    EvoEvolutionStore as EvolutionStore, EvoKernel, EvoSandboxPolicy as SandboxPolicy,
+    EvoSelectorInput as SelectorInput, EvolutionNetworkNode, FetchQuery, JsonlEvolutionStore,
+    LocalProcessSandbox, ValidationPlan, ValidationStage,
 };
 #[cfg(feature = "full-evolution-experimental")]
 use oris_runtime::governor::{DefaultGovernor, GovernorConfig};
@@ -838,49 +839,23 @@ fn merge_signals(base: &[String], extra: &[String]) -> Vec<String> {
 
 #[cfg(feature = "full-evolution-experimental")]
 fn repair_quality_gate(plan: &str) -> ExampleResult<QualityCheckResult> {
-    let lower = plan.to_ascii_lowercase();
+    let report = evaluate_repair_quality_gate(plan);
     let checks = vec![
-        (
-            "包含根因分析".to_string(),
-            plan.contains("根因")
-                || plan.contains("原因分析")
-                || plan.contains("问题定位")
-                || lower.contains("root cause"),
-        ),
-        (
-            "包含修复步骤".to_string(),
-            plan.contains("修复步骤")
-                || plan.contains("修复方案")
-                || plan.contains("修复")
-                || plan.contains("处理步骤")
-                || lower.contains("fix")
-                || lower.contains("remediation"),
-        ),
-        (
-            "包含验证命令".to_string(),
-            plan.contains("验证命令")
-                || plan.contains("验证步骤")
-                || plan.contains("验证")
-                || plan.contains("回归测试")
-                || lower.contains("verification")
-                || lower.contains("validate"),
-        ),
-        (
-            "包含回滚方案".to_string(),
-            plan.contains("回滚方案")
-                || plan.contains("回滚")
-                || plan.contains("恢复方案")
-                || plan.contains("撤销")
-                || lower.contains("rollback"),
-        ),
+        ("包含根因分析".to_string(), report.root_cause),
+        ("包含修复步骤".to_string(), report.fix),
+        ("包含验证命令".to_string(), report.verification),
+        ("包含回滚方案".to_string(), report.rollback),
         (
             "包含unknown command故障上下文".to_string(),
-            lower.contains("unknown command")
-                || lower.contains("process")
-                || lower.contains("proccess")
-                || plan.contains("命令不存在")
-                || plan.contains("命令未找到")
-                || plan.contains("命令错误"),
+            report.incident_anchor,
+        ),
+        (
+            "结构化修复信息至少满足3项（根因/修复/验证/回滚）".to_string(),
+            report.structure_score >= 3,
+        ),
+        (
+            "包含可执行验证命令或验证计划".to_string(),
+            report.has_actionable_command || report.verification,
         ),
     ];
 

--- a/crates/oris-runtime/tests/agent_official_experience_reuse.rs
+++ b/crates/oris-runtime/tests/agent_official_experience_reuse.rs
@@ -11,7 +11,7 @@ use oris_runtime::agent::middleware::{Middleware, MiddlewareContext, MiddlewareE
 use oris_runtime::agent::{create_agent_from_llm, UnifiedAgent};
 use oris_runtime::error::ToolError;
 use oris_runtime::evolution::{
-    CommandValidator, EvoEvolutionStore as EvolutionStore, EvoKernel,
+    evaluate_repair_quality_gate, CommandValidator, EvoEvolutionStore as EvolutionStore, EvoKernel,
     EvoSandboxPolicy as SandboxPolicy, EvoSelectorInput as SelectorInput, EvolutionNetworkNode,
     FetchQuery, JsonlEvolutionStore, LocalProcessSandbox, ValidationPlan,
 };
@@ -494,83 +494,24 @@ fn build_evo(
 }
 
 fn quality_gate(plan: &str) {
-    fn contains_any(haystack: &str, needles: &[&str]) -> bool {
-        needles.iter().any(|needle| haystack.contains(needle))
-    }
-
-    let lower = plan.to_ascii_lowercase();
-    let root_cause = contains_any(
-        plan,
-        &["根因", "原因分析", "问题定位", "原因定位", "根本原因"],
-    ) || contains_any(
-        &lower,
-        &[
-            "root cause",
-            "cause analysis",
-            "problem diagnosis",
-            "diagnosis",
-        ],
-    );
-    let fix = contains_any(
-        plan,
-        &["修复步骤", "修复方案", "处理步骤", "修复建议", "整改方案"],
-    ) || contains_any(
-        &lower,
-        &[
-            "fix",
-            "remediation",
-            "mitigation",
-            "resolution",
-            "repair steps",
-        ],
-    );
-    let verification = contains_any(
-        plan,
-        &["验证命令", "验证步骤", "回归测试", "验证方式", "验收步骤"],
-    ) || contains_any(
-        &lower,
-        &[
-            "verification",
-            "validate",
-            "regression test",
-            "smoke test",
-            "test command",
-        ],
-    );
-    let rollback = contains_any(plan, &["回滚方案", "回滚步骤", "恢复方案", "撤销方案"])
-        || contains_any(&lower, &["rollback", "revert", "fallback plan", "undo"]);
-    let incident_anchor = contains_any(
-        &lower,
-        &[
-            "unknown command",
-            "process",
-            "proccess",
-            "command not found",
-        ],
-    ) || contains_any(plan, &["命令不存在", "命令未找到", "未知命令"]);
-
-    let structure_score = [root_cause, fix, verification, rollback]
-        .into_iter()
-        .filter(|ok| *ok)
-        .count();
-    let has_actionable_command = contains_any(
-        &lower,
-        &[
-            "cargo ", "git ", "python ", "pip ", "npm ", "pnpm ", "yarn ",
-        ],
-    );
+    let report = evaluate_repair_quality_gate(plan);
     let preview = plan.chars().take(240).collect::<String>();
 
     assert!(
-        incident_anchor,
+        report.incident_anchor,
         "quality_gate missing incident anchor; preview={preview}"
     );
     assert!(
-        structure_score >= 3,
-        "quality_gate structure too weak (score={structure_score}); root={root_cause} fix={fix} verification={verification} rollback={rollback}; preview={preview}"
+        report.structure_score >= 3,
+        "quality_gate structure too weak (score={}); root={} fix={} verification={} rollback={}; preview={preview}",
+        report.structure_score,
+        report.root_cause,
+        report.fix,
+        report.verification,
+        report.rollback
     );
     assert!(
-        has_actionable_command || verification,
+        report.has_actionable_command || report.verification,
         "quality_gate missing actionable verification command; preview={preview}"
     );
 }


### PR DESCRIPTION
## Summary
- add a shared EvoKernel repair quality gate evaluator: `evaluate_repair_quality_gate`
- expose machine-readable quality dimensions via `RepairQualityGateReport`
- reuse the same evaluator in runtime integration test and official experience reuse example
- add EvoKernel unit tests for semantic-variant pass and missing-incident fail cases

## Validation
- cargo fmt --all
- cargo test -p oris-evokernel --lib repair_quality_gate_
- cargo test -p oris-runtime --test agent_official_experience_reuse quality_gate_ --features full-evolution-experimental -- --nocapture
- cargo check -p oris-runtime --example agent_official_experience_reuse --features full-evolution-experimental

Closes #201
