### PR TITLE
[EVO26-W6-09-01][P0] 统一 Replay Fallback / Planner Directive 契约与映射

### DIFF
--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -173,6 +173,10 @@ pub struct A2aTaskSessionCompletionRequest {
     pub capsule_id: Option<String>,
     pub reasoning_steps_avoided: u64,
     pub fallback_reason: Option<String>,
+    pub reason_code: Option<ReplayFallbackReasonCode>,
+    pub repair_hint: Option<String>,
+    pub next_action: Option<ReplayFallbackNextAction>,
+    pub confidence: Option<u8>,
     pub task_class_id: String,
     pub task_label: String,
 }
@@ -335,6 +339,115 @@ pub enum ReplayPlannerDirective {
     PlanFallback,
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayFallbackReasonCode {
+    NoCandidateAfterSelect,
+    ScoreBelowThreshold,
+    CandidateHasNoCapsule,
+    MutationPayloadMissing,
+    PatchApplyFailed,
+    ValidationFailed,
+    UnmappedFallbackReason,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayFallbackNextAction {
+    PlanFromScratch,
+    ValidateSignalsThenPlan,
+    RebuildCapsule,
+    RegenerateMutationPayload,
+    RebasePatchAndRetry,
+    RepairAndRevalidate,
+    EscalateFailClosed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplayFallbackContract {
+    pub reason_code: ReplayFallbackReasonCode,
+    pub fallback_reason: String,
+    pub repair_hint: String,
+    pub next_action: ReplayFallbackNextAction,
+    /// Confidence score in [0, 100].
+    pub confidence: u8,
+}
+
+pub fn infer_replay_fallback_reason_code(reason: &str) -> Option<ReplayFallbackReasonCode> {
+    let normalized = reason.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized == "no_candidate_after_select" || normalized.contains("no matching gene") {
+        return Some(ReplayFallbackReasonCode::NoCandidateAfterSelect);
+    }
+    if normalized == "score_below_threshold" || normalized.contains("below replay threshold") {
+        return Some(ReplayFallbackReasonCode::ScoreBelowThreshold);
+    }
+    if normalized == "candidate_has_no_capsule" || normalized.contains("has no capsule") {
+        return Some(ReplayFallbackReasonCode::CandidateHasNoCapsule);
+    }
+    if normalized == "mutation_payload_missing" || normalized.contains("payload missing") {
+        return Some(ReplayFallbackReasonCode::MutationPayloadMissing);
+    }
+    if normalized == "patch_apply_failed" || normalized.contains("patch apply failed") {
+        return Some(ReplayFallbackReasonCode::PatchApplyFailed);
+    }
+    if normalized == "validation_failed" || normalized.contains("validation failed") {
+        return Some(ReplayFallbackReasonCode::ValidationFailed);
+    }
+    None
+}
+
+pub fn normalize_replay_fallback_contract(
+    planner_directive: &ReplayPlannerDirective,
+    fallback_reason: Option<&str>,
+    reason_code: Option<ReplayFallbackReasonCode>,
+    repair_hint: Option<&str>,
+    next_action: Option<ReplayFallbackNextAction>,
+    confidence: Option<u8>,
+) -> Option<ReplayFallbackContract> {
+    if !matches!(planner_directive, ReplayPlannerDirective::PlanFallback) {
+        return None;
+    }
+
+    let normalized_reason = normalize_optional_text(fallback_reason);
+    let normalized_repair_hint = normalize_optional_text(repair_hint);
+    let mut resolved_reason_code = reason_code
+        .or_else(|| {
+            normalized_reason
+                .as_deref()
+                .and_then(infer_replay_fallback_reason_code)
+        })
+        .unwrap_or(ReplayFallbackReasonCode::UnmappedFallbackReason);
+    let mut defaults = replay_fallback_defaults(&resolved_reason_code);
+
+    let mut force_fail_closed = false;
+    if let Some(provided_action) = next_action {
+        if provided_action != defaults.next_action {
+            resolved_reason_code = ReplayFallbackReasonCode::UnmappedFallbackReason;
+            defaults = replay_fallback_defaults(&resolved_reason_code);
+            force_fail_closed = true;
+        }
+    }
+
+    Some(ReplayFallbackContract {
+        reason_code: resolved_reason_code,
+        fallback_reason: normalized_reason.unwrap_or_else(|| defaults.fallback_reason.to_string()),
+        repair_hint: normalized_repair_hint.unwrap_or_else(|| defaults.repair_hint.to_string()),
+        next_action: if force_fail_closed {
+            defaults.next_action
+        } else {
+            next_action.unwrap_or(defaults.next_action)
+        },
+        confidence: if force_fail_closed {
+            defaults.confidence
+        } else {
+            confidence.unwrap_or(defaults.confidence).min(100)
+        },
+    })
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplayFeedback {
     pub used_capsule: bool,
@@ -342,9 +455,81 @@ pub struct ReplayFeedback {
     pub planner_directive: ReplayPlannerDirective,
     pub reasoning_steps_avoided: u64,
     pub fallback_reason: Option<String>,
+    pub reason_code: Option<ReplayFallbackReasonCode>,
+    pub repair_hint: Option<String>,
+    pub next_action: Option<ReplayFallbackNextAction>,
+    pub confidence: Option<u8>,
     pub task_class_id: String,
     pub task_label: String,
     pub summary: String,
+}
+
+fn normalize_optional_text(value: Option<&str>) -> Option<String> {
+    let trimmed = value?.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReplayFallbackDefaults {
+    fallback_reason: &'static str,
+    repair_hint: &'static str,
+    next_action: ReplayFallbackNextAction,
+    confidence: u8,
+}
+
+fn replay_fallback_defaults(reason_code: &ReplayFallbackReasonCode) -> ReplayFallbackDefaults {
+    match reason_code {
+        ReplayFallbackReasonCode::NoCandidateAfterSelect => ReplayFallbackDefaults {
+            fallback_reason: "no matching gene",
+            repair_hint:
+                "No reusable capsule matched deterministic signals; run planner for a minimal patch.",
+            next_action: ReplayFallbackNextAction::PlanFromScratch,
+            confidence: 92,
+        },
+        ReplayFallbackReasonCode::ScoreBelowThreshold => ReplayFallbackDefaults {
+            fallback_reason: "candidate score below replay threshold",
+            repair_hint:
+                "Best replay candidate is below threshold; validate task signals and re-plan.",
+            next_action: ReplayFallbackNextAction::ValidateSignalsThenPlan,
+            confidence: 86,
+        },
+        ReplayFallbackReasonCode::CandidateHasNoCapsule => ReplayFallbackDefaults {
+            fallback_reason: "candidate gene has no capsule",
+            repair_hint: "Matched gene has no executable capsule; rebuild capsule from planner output.",
+            next_action: ReplayFallbackNextAction::RebuildCapsule,
+            confidence: 80,
+        },
+        ReplayFallbackReasonCode::MutationPayloadMissing => ReplayFallbackDefaults {
+            fallback_reason: "mutation payload missing from store",
+            repair_hint:
+                "Mutation payload is missing; regenerate and persist a minimal mutation payload.",
+            next_action: ReplayFallbackNextAction::RegenerateMutationPayload,
+            confidence: 76,
+        },
+        ReplayFallbackReasonCode::PatchApplyFailed => ReplayFallbackDefaults {
+            fallback_reason: "replay patch apply failed",
+            repair_hint: "Replay patch cannot be applied cleanly; rebase patch and retry planning.",
+            next_action: ReplayFallbackNextAction::RebasePatchAndRetry,
+            confidence: 68,
+        },
+        ReplayFallbackReasonCode::ValidationFailed => ReplayFallbackDefaults {
+            fallback_reason: "replay validation failed",
+            repair_hint: "Replay validation failed; produce a repair mutation and re-run validation.",
+            next_action: ReplayFallbackNextAction::RepairAndRevalidate,
+            confidence: 64,
+        },
+        ReplayFallbackReasonCode::UnmappedFallbackReason => ReplayFallbackDefaults {
+            fallback_reason: "unmapped replay fallback reason",
+            repair_hint:
+                "Fallback reason is unmapped; fail closed and require explicit planner intervention.",
+            next_action: ReplayFallbackNextAction::EscalateFailClosed,
+            confidence: 0,
+        },
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -425,6 +610,75 @@ mod tests {
     fn negotiate_supported_protocol_returns_none_without_overlap() {
         let req = handshake_request_with_versions(&["0.0.1"]);
         assert!(req.negotiate_supported_protocol().is_none());
+    }
+
+    #[test]
+    fn normalize_replay_fallback_contract_maps_known_reason() {
+        let contract = normalize_replay_fallback_contract(
+            &ReplayPlannerDirective::PlanFallback,
+            Some("no matching gene"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("contract should exist");
+
+        assert_eq!(
+            contract.reason_code,
+            ReplayFallbackReasonCode::NoCandidateAfterSelect
+        );
+        assert_eq!(
+            contract.next_action,
+            ReplayFallbackNextAction::PlanFromScratch
+        );
+        assert_eq!(contract.confidence, 92);
+    }
+
+    #[test]
+    fn normalize_replay_fallback_contract_fails_closed_for_unknown_reason() {
+        let contract = normalize_replay_fallback_contract(
+            &ReplayPlannerDirective::PlanFallback,
+            Some("something unexpected"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("contract should exist");
+
+        assert_eq!(
+            contract.reason_code,
+            ReplayFallbackReasonCode::UnmappedFallbackReason
+        );
+        assert_eq!(
+            contract.next_action,
+            ReplayFallbackNextAction::EscalateFailClosed
+        );
+        assert_eq!(contract.confidence, 0);
+    }
+
+    #[test]
+    fn normalize_replay_fallback_contract_rejects_conflicting_next_action() {
+        let contract = normalize_replay_fallback_contract(
+            &ReplayPlannerDirective::PlanFallback,
+            Some("replay validation failed"),
+            Some(ReplayFallbackReasonCode::ValidationFailed),
+            None,
+            Some(ReplayFallbackNextAction::PlanFromScratch),
+            Some(88),
+        )
+        .expect("contract should exist");
+
+        assert_eq!(
+            contract.reason_code,
+            ReplayFallbackReasonCode::UnmappedFallbackReason
+        );
+        assert_eq!(
+            contract.next_action,
+            ReplayFallbackNextAction::EscalateFailClosed
+        );
+        assert_eq!(contract.confidence, 0);
     }
 }
 

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -9,7 +9,8 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
-    AgentRole, BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
+    infer_replay_fallback_reason_code, normalize_replay_fallback_contract, AgentRole,
+    BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
     CoordinationResult, CoordinationTask, ExecutionFeedback,
     MutationProposal as AgentMutationProposal, ReplayFeedback, ReplayPlannerDirective,
     SupervisedDevloopOutcome, SupervisedDevloopRequest, SupervisedDevloopStatus,
@@ -2411,11 +2412,21 @@ impl<S: KernelState> EvoKernel<S> {
             ReplayPlannerDirective::PlanFallback
         };
         let reasoning_steps_avoided = u64::from(decision.used_capsule);
-        let fallback_reason = if decision.fallback_to_planner {
-            Some(decision.reason.clone())
-        } else {
-            None
-        };
+        let reason_code_hint = decision
+            .detect_evidence
+            .mismatch_reasons
+            .first()
+            .and_then(|reason| infer_replay_fallback_reason_code(reason));
+        let fallback_contract = normalize_replay_fallback_contract(
+            &planner_directive,
+            decision
+                .fallback_to_planner
+                .then_some(decision.reason.as_str()),
+            reason_code_hint,
+            None,
+            None,
+            None,
+        );
         let summary = if decision.used_capsule {
             format!("reused prior capsule for task class '{task_label}'; skip planner")
         } else {
@@ -2430,7 +2441,21 @@ impl<S: KernelState> EvoKernel<S> {
             capsule_id: decision.capsule_id.clone(),
             planner_directive,
             reasoning_steps_avoided,
-            fallback_reason,
+            fallback_reason: fallback_contract
+                .as_ref()
+                .map(|contract| contract.fallback_reason.clone()),
+            reason_code: fallback_contract
+                .as_ref()
+                .map(|contract| contract.reason_code),
+            repair_hint: fallback_contract
+                .as_ref()
+                .map(|contract| contract.repair_hint.clone()),
+            next_action: fallback_contract
+                .as_ref()
+                .map(|contract| contract.next_action),
+            confidence: fallback_contract
+                .as_ref()
+                .map(|contract| contract.confidence),
             task_class_id,
             task_label,
             summary,

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -10,8 +10,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{Duration, Utc};
 use oris_agent_contract::{
-    AgentTask, BoundedTaskClass, HumanApproval, MutationProposal, ReplayPlannerDirective,
-    SupervisedDevloopRequest, SupervisedDevloopStatus,
+    AgentTask, BoundedTaskClass, HumanApproval, MutationProposal, ReplayFallbackNextAction,
+    ReplayFallbackReasonCode, ReplayPlannerDirective, SupervisedDevloopRequest,
+    SupervisedDevloopStatus,
 };
 use oris_evokernel::{
     extract_deterministic_signals, prepare_mutation, CommandValidator, EvoAssetState,
@@ -709,6 +710,16 @@ async fn replay_feedback_surfaces_planner_hints_and_reasoning_savings() {
         cold_feedback.fallback_reason.as_deref(),
         Some("no matching gene")
     );
+    assert_eq!(
+        cold_feedback.reason_code,
+        Some(ReplayFallbackReasonCode::NoCandidateAfterSelect)
+    );
+    assert_eq!(
+        cold_feedback.next_action,
+        Some(ReplayFallbackNextAction::PlanFromScratch)
+    );
+    assert!(cold_feedback.repair_hint.is_some());
+    assert_eq!(cold_feedback.confidence, Some(92));
     assert!(!cold_feedback.task_class_id.is_empty());
     assert_eq!(cold_feedback.task_label, "missing readme");
 
@@ -734,6 +745,10 @@ async fn replay_feedback_surfaces_planner_hints_and_reasoning_savings() {
     assert!(replay_feedback.used_capsule);
     assert_eq!(replay_feedback.capsule_id, Some(captured.id));
     assert_eq!(replay_feedback.fallback_reason, None);
+    assert_eq!(replay_feedback.reason_code, None);
+    assert_eq!(replay_feedback.repair_hint, None);
+    assert_eq!(replay_feedback.next_action, None);
+    assert_eq!(replay_feedback.confidence, None);
     assert_eq!(replay_feedback.task_class_id, cold_feedback.task_class_id);
     assert_eq!(replay_feedback.task_label, "missing readme");
     assert!(events.iter().any(|stored| matches!(

--- a/crates/oris-orchestrator/src/runtime_client.rs
+++ b/crates/oris-orchestrator/src/runtime_client.rs
@@ -5,10 +5,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use oris_agent_contract::{
-    A2aCapability, A2aHandshakeRequest, A2aHandshakeResponse, A2aProtocol, A2aTaskLifecycleState,
+    infer_replay_fallback_reason_code, normalize_replay_fallback_contract, A2aCapability,
+    A2aHandshakeRequest, A2aHandshakeResponse, A2aProtocol, A2aTaskLifecycleState,
     A2aTaskSessionAck, A2aTaskSessionCompletionRequest, A2aTaskSessionCompletionResponse,
     A2aTaskSessionResult, A2aTaskSessionStartRequest, AgentCapabilityLevel, AgentRole,
-    ReplayFeedback, ReplayPlannerDirective, A2A_TASK_SESSION_PROTOCOL_VERSION,
+    ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
+    A2A_TASK_SESSION_PROTOCOL_VERSION,
 };
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -65,6 +67,10 @@ pub struct A2aSessionCompletion {
     pub used_capsule: bool,
     pub capsule_id: Option<String>,
     pub fallback_reason: Option<String>,
+    pub reason_code: Option<ReplayFallbackReasonCode>,
+    pub repair_hint: Option<String>,
+    pub next_action: Option<ReplayFallbackNextAction>,
+    pub confidence: Option<u8>,
     pub task_class_id: String,
     pub task_label: String,
 }
@@ -79,6 +85,10 @@ impl A2aSessionCompletion {
             used_capsule,
             capsule_id: None,
             fallback_reason: None,
+            reason_code: None,
+            repair_hint: None,
+            next_action: None,
+            confidence: None,
             task_class_id: "issue-automation".to_string(),
             task_label: "issue-automation".to_string(),
         }
@@ -98,6 +108,10 @@ impl A2aSessionCompletion {
             capsule_id: self.capsule_id,
             reasoning_steps_avoided: if self.used_capsule { 1 } else { 0 },
             fallback_reason: self.fallback_reason,
+            reason_code: self.reason_code,
+            repair_hint: self.repair_hint,
+            next_action: self.next_action,
+            confidence: self.confidence,
             task_class_id: self.task_class_id,
             task_label: self.task_label,
         }
@@ -332,16 +346,46 @@ impl RuntimeA2aClient for InMemoryRuntimeA2aClient {
                 RuntimeClientError::new(format!("session not found: {}", session_id))
             })?;
 
+        let planner_directive = if request.used_capsule {
+            ReplayPlannerDirective::SkipPlanner
+        } else {
+            ReplayPlannerDirective::PlanFallback
+        };
+        let reason_code_hint = request.reason_code.or_else(|| {
+            request
+                .fallback_reason
+                .as_deref()
+                .and_then(infer_replay_fallback_reason_code)
+        });
+        let fallback_contract = normalize_replay_fallback_contract(
+            &planner_directive,
+            request.fallback_reason.as_deref(),
+            reason_code_hint,
+            request.repair_hint.as_deref(),
+            request.next_action,
+            request.confidence,
+        );
+
         let replay_feedback = ReplayFeedback {
             used_capsule: request.used_capsule,
             capsule_id: request.capsule_id,
-            planner_directive: if request.used_capsule {
-                ReplayPlannerDirective::SkipPlanner
-            } else {
-                ReplayPlannerDirective::PlanFallback
-            },
+            planner_directive,
             reasoning_steps_avoided: if request.used_capsule { 1 } else { 0 },
-            fallback_reason: request.fallback_reason,
+            fallback_reason: fallback_contract
+                .as_ref()
+                .map(|contract| contract.fallback_reason.clone()),
+            reason_code: fallback_contract
+                .as_ref()
+                .map(|contract| contract.reason_code),
+            repair_hint: fallback_contract
+                .as_ref()
+                .map(|contract| contract.repair_hint.clone()),
+            next_action: fallback_contract
+                .as_ref()
+                .map(|contract| contract.next_action),
+            confidence: fallback_contract
+                .as_ref()
+                .map(|contract| contract.confidence),
             task_class_id: request.task_class_id,
             task_label: request.task_label,
             summary: request.summary.clone(),

--- a/crates/oris-runtime/src/execution_server/api_handlers.rs
+++ b/crates/oris-runtime/src/execution_server/api_handlers.rs
@@ -31,8 +31,9 @@ use tokio::sync::RwLock;
     feature = "evolution-network-experimental"
 ))]
 use crate::agent_contract::{
-    A2aCapability, A2aErrorCode, A2aErrorEnvelope, A2aHandshakeRequest, A2aHandshakeResponse,
-    A2aProtocol, A2aTaskLifecycleEvent, A2aTaskLifecycleState, A2aTaskSessionAck,
+    infer_replay_fallback_reason_code, normalize_replay_fallback_contract, A2aCapability,
+    A2aErrorCode, A2aErrorEnvelope, A2aHandshakeRequest, A2aHandshakeResponse, A2aProtocol,
+    A2aTaskLifecycleEvent, A2aTaskLifecycleState, A2aTaskSessionAck,
     A2aTaskSessionCompletionRequest, A2aTaskSessionCompletionResponse,
     A2aTaskSessionDispatchRequest, A2aTaskSessionProgressItem, A2aTaskSessionProgressRequest,
     A2aTaskSessionResult, A2aTaskSessionSnapshot, A2aTaskSessionStartRequest, A2aTaskSessionState,
@@ -1618,6 +1619,10 @@ pub struct A2aCompatReportRequest {
     capsule_id: Option<String>,
     reasoning_steps_avoided: Option<u64>,
     fallback_reason: Option<String>,
+    reason_code: Option<crate::agent_contract::ReplayFallbackReasonCode>,
+    repair_hint: Option<String>,
+    next_action: Option<crate::agent_contract::ReplayFallbackNextAction>,
+    confidence: Option<u8>,
     task_class_id: Option<String>,
     task_label: Option<String>,
 }
@@ -1668,6 +1673,14 @@ pub struct A2aCompatTaskCompleteRequest {
     reasoning_steps_avoided: Option<u64>,
     #[serde(default)]
     fallback_reason: Option<String>,
+    #[serde(default)]
+    reason_code: Option<crate::agent_contract::ReplayFallbackReasonCode>,
+    #[serde(default)]
+    repair_hint: Option<String>,
+    #[serde(default)]
+    next_action: Option<crate::agent_contract::ReplayFallbackNextAction>,
+    #[serde(default)]
+    confidence: Option<u8>,
     #[serde(default)]
     task_class_id: Option<String>,
     #[serde(default)]
@@ -1756,6 +1769,14 @@ pub struct A2aCompatWorkCompleteRequest {
     reasoning_steps_avoided: Option<u64>,
     #[serde(default)]
     fallback_reason: Option<String>,
+    #[serde(default)]
+    reason_code: Option<crate::agent_contract::ReplayFallbackReasonCode>,
+    #[serde(default)]
+    repair_hint: Option<String>,
+    #[serde(default)]
+    next_action: Option<crate::agent_contract::ReplayFallbackNextAction>,
+    #[serde(default)]
+    confidence: Option<u8>,
     #[serde(default)]
     task_class_id: Option<String>,
     #[serde(default)]
@@ -4873,16 +4894,44 @@ fn ensure_task_session_protocol_version(version: &str, rid: &str) -> Result<(), 
     feature = "evolution-network-experimental"
 ))]
 fn derive_replay_feedback(req: &A2aTaskSessionCompletionRequest) -> ReplayFeedback {
+    let planner_directive = if req.used_capsule {
+        ReplayPlannerDirective::SkipPlanner
+    } else {
+        ReplayPlannerDirective::PlanFallback
+    };
+    let reason_code_hint = req.reason_code.or_else(|| {
+        req.fallback_reason
+            .as_deref()
+            .and_then(infer_replay_fallback_reason_code)
+    });
+    let fallback_contract = normalize_replay_fallback_contract(
+        &planner_directive,
+        req.fallback_reason.as_deref(),
+        reason_code_hint,
+        req.repair_hint.as_deref(),
+        req.next_action,
+        req.confidence,
+    );
     ReplayFeedback {
         used_capsule: req.used_capsule,
         capsule_id: req.capsule_id.clone(),
-        planner_directive: if req.used_capsule {
-            ReplayPlannerDirective::SkipPlanner
-        } else {
-            ReplayPlannerDirective::PlanFallback
-        },
+        planner_directive,
         reasoning_steps_avoided: req.reasoning_steps_avoided,
-        fallback_reason: req.fallback_reason.clone(),
+        fallback_reason: fallback_contract
+            .as_ref()
+            .map(|contract| contract.fallback_reason.clone()),
+        reason_code: fallback_contract
+            .as_ref()
+            .map(|contract| contract.reason_code),
+        repair_hint: fallback_contract
+            .as_ref()
+            .map(|contract| contract.repair_hint.clone()),
+        next_action: fallback_contract
+            .as_ref()
+            .map(|contract| contract.next_action),
+        confidence: fallback_contract
+            .as_ref()
+            .map(|contract| contract.confidence),
         task_class_id: req.task_class_id.clone(),
         task_label: req.task_label.clone(),
         summary: req.summary.clone(),
@@ -6487,6 +6536,10 @@ pub async fn evolution_a2a_task_complete(
             capsule_id: req.capsule_id,
             reasoning_steps_avoided: req.reasoning_steps_avoided,
             fallback_reason: req.fallback_reason,
+            reason_code: req.reason_code,
+            repair_hint: req.repair_hint,
+            next_action: req.next_action,
+            confidence: req.confidence,
             task_class_id: req.task_class_id,
             task_label: req.task_label,
         }),
@@ -6869,6 +6922,10 @@ pub async fn evolution_a2a_work_complete(
             capsule_id: req.capsule_id,
             reasoning_steps_avoided: req.reasoning_steps_avoided,
             fallback_reason: req.fallback_reason,
+            reason_code: req.reason_code,
+            repair_hint: req.repair_hint,
+            next_action: req.next_action,
+            confidence: req.confidence,
             task_class_id: req.task_class_id,
             task_label: req.task_label,
         }),
@@ -7392,6 +7449,10 @@ pub async fn evolution_a2a_tasks_report(
                     capsule_id: req.capsule_id,
                     reasoning_steps_avoided: req.reasoning_steps_avoided.unwrap_or(0),
                     fallback_reason: req.fallback_reason,
+                    reason_code: req.reason_code,
+                    repair_hint: req.repair_hint,
+                    next_action: req.next_action,
+                    confidence: req.confidence,
                     task_class_id: req.task_class_id.unwrap_or_else(|| "unknown".into()),
                     task_label: req.task_label.unwrap_or_else(|| task_id.clone()),
                 }),
@@ -15099,6 +15160,10 @@ mod tests {
             complete_json["data"]["result"]["replay_feedback"]["reasoning_steps_avoided"],
             7
         );
+        assert_eq!(
+            complete_json["data"]["result"]["replay_feedback"]["reason_code"],
+            serde_json::Value::Null
+        );
 
         let snapshot_req = Request::builder()
             .method(Method::GET)
@@ -15207,6 +15272,18 @@ mod tests {
         assert_eq!(
             complete_json["data"]["result"]["replay_feedback"]["planner_directive"],
             "PlanFallback"
+        );
+        assert_eq!(
+            complete_json["data"]["result"]["replay_feedback"]["reason_code"],
+            "unmapped_fallback_reason"
+        );
+        assert_eq!(
+            complete_json["data"]["result"]["replay_feedback"]["next_action"],
+            "escalate_fail_closed"
+        );
+        assert_eq!(
+            complete_json["data"]["result"]["replay_feedback"]["confidence"],
+            0
         );
     }
 

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -61,6 +61,9 @@ fn full_evolution_experimental_paths_resolve() {
     assert_type::<oris_runtime::agent_contract::ExecutionFeedback>();
     assert_type::<oris_runtime::agent_contract::ReplayFeedback>();
     assert_type::<oris_runtime::agent_contract::ReplayPlannerDirective>();
+    assert_type::<oris_runtime::agent_contract::ReplayFallbackReasonCode>();
+    assert_type::<oris_runtime::agent_contract::ReplayFallbackNextAction>();
+    assert_type::<oris_runtime::agent_contract::ReplayFallbackContract>();
     assert_type::<oris_runtime::agent_contract::BoundedTaskClass>();
     assert_type::<oris_runtime::agent_contract::HumanApproval>();
     assert_type::<oris_runtime::agent_contract::SupervisedDevloopRequest>();
@@ -104,6 +107,8 @@ fn full_evolution_experimental_paths_resolve() {
         oris_runtime::agent_contract::A2aCapability::Coordination,
     ]);
     assert!(accepted.accepted);
+    let _ = oris_runtime::agent_contract::infer_replay_fallback_reason_code;
+    let _ = oris_runtime::agent_contract::normalize_replay_fallback_contract;
     let rejected = oris_runtime::agent_contract::A2aHandshakeResponse::reject(
         oris_runtime::agent_contract::A2aErrorCode::UnsupportedCapability,
         "none",

--- a/docs/evokernel/evolution.md
+++ b/docs/evokernel/evolution.md
@@ -163,8 +163,18 @@ If replay succeeds, LLM reasoning is skipped.
 Agent-facing callers can now convert a replay result into structured
 `ReplayFeedback` via `replay_feedback_for_agent(...)`. That boundary exposes a
 deterministic task-class id, a human-readable task label, a planner directive
-(`SkipPlanner` vs `PlanFallback`), and explicit fallback reasons so proposal
-pipelines can decide whether to continue planning or accept reuse immediately.
+(`SkipPlanner` vs `PlanFallback`), and explicit fallback contract fields:
+
+- `reason_code` (machine-readable, stable fallback reason)
+- `fallback_reason` (human-readable fallback explanation)
+- `repair_hint` (deterministic minimum repair guidance)
+- `next_action` (executable next step)
+- `confidence` (`0..100`, contract confidence)
+
+For unknown fallback inputs, the contract is fail-closed by default
+(`reason_code=unmapped_fallback_reason`, `next_action=escalate_fail_closed`).
+This avoids silently accepting unmapped semantics across API, events, and
+callers.
 
 When the caller needs the reuse event tied to a specific execution, use
 `replay_or_fallback_for_run(...)` so the resulting `CapsuleReused` event carries


### PR DESCRIPTION
## Summary
- add a reusable replay fallback contract in `oris-agent-contract` with unified fields: `reason_code`, `fallback_reason`, `repair_hint`, `next_action`, `confidence`
- add deterministic reason mapping + fail-closed default (`unmapped_fallback_reason` -> `escalate_fail_closed`)
- wire the normalized contract into `EvoKernel::replay_feedback_for_agent`, runtime A2A completion ingestion, and orchestrator runtime client conversion
- extend compatibility request plumbing to carry structured directive fields end-to-end
- update replay feedback regression assertions and evolution docs

## Validation
- `cargo fmt --all`
- `cargo test -p oris-agent-contract`
- `cargo test -p oris-evokernel --test evolution_lifecycle_regression replay_feedback_surfaces_planner_hints_and_reasoning_savings`
- `cargo test -p oris-runtime --lib replay_feedback`
- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental -- --nocapture`
- `cargo test -p oris-orchestrator runtime_client_contract`

## Notes
- `cargo check -p oris-runtime --features a2a-production` currently fails on pre-existing `State<ExecutionApiState>` field-access errors in `api_handlers.rs` (`state.runtime_repo` access in Evomap handlers), unrelated to this PR's contract changes.

Closes #208
