### PR TITLE
[EVO26-W6-10-03] Wire self-evolution gate into pre-release blocking flow

### DIFF
--- a/crates/oris-runtime/tests/agent_self_evolution_travel_network.rs
+++ b/crates/oris-runtime/tests/agent_self_evolution_travel_network.rs
@@ -10,7 +10,8 @@ use oris_runtime::agent_contract::MutationProposal;
 use oris_runtime::evolution::{
     CommandValidator, EvoAssetState, EvoEvolutionStore as EvolutionStore, EvoKernel,
     EvoSandboxPolicy as SandboxPolicy, EvoSelectorInput as SelectorInput, EvolutionNetworkNode,
-    FetchQuery, JsonlEvolutionStore, LocalProcessSandbox, PublishRequest, ValidationPlan,
+    FetchQuery, JsonlEvolutionStore, LocalProcessSandbox, PublishRequest,
+    ReplayRoiReleaseGateStatus, ReplayRoiReleaseGateThresholds, ValidationPlan,
 };
 use oris_runtime::governor::{DefaultGovernor, GovernorConfig};
 use oris_runtime::kernel::{
@@ -530,6 +531,13 @@ fn write_jsonl_values(path: &Path, values: &[Value]) {
         payload.push('\n');
     }
     std::fs::write(path, payload).unwrap();
+}
+
+fn write_json_value(path: &Path, value: &Value) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
 }
 
 fn event_kind(record: &Value) -> Option<&str> {
@@ -1065,6 +1073,17 @@ async fn travel_network_demo_flow_captures_publishes_imports_and_replays() {
     assert!(roi_summary.replay_attempts_total >= 2);
     assert!(roi_summary.replay_success_total >= 1);
     assert!(roi_summary.reasoning_avoided_tokens_total >= 1);
+    let release_gate_contract = consumer_evo
+        .replay_roi_release_gate_contract(24 * 60 * 60, ReplayRoiReleaseGateThresholds::default())
+        .unwrap();
+    assert_eq!(
+        release_gate_contract.output.status,
+        ReplayRoiReleaseGateStatus::FailClosed
+    );
+    assert!(
+        !release_gate_contract.output.failed_checks.is_empty(),
+        "release gate should expose failed checks in demo flow"
+    );
     append_audit_log(
         &audit_log,
         format!(
@@ -1084,6 +1103,45 @@ async fn travel_network_demo_flow_captures_publishes_imports_and_replays() {
             roi_summary.replay_roi
         ),
     );
+    append_audit_log(
+        &audit_log,
+        format!(
+            "[STEP] release_gate status={:?} failed_checks={:?}",
+            release_gate_contract.output.status, release_gate_contract.output.failed_checks
+        ),
+    );
+    let release_gate_evidence = json!({
+        "gate": "self-evolution-release-gate",
+        "status": release_gate_contract.output.status,
+        "summary": release_gate_contract.output.summary,
+        "failed_checks": release_gate_contract.output.failed_checks,
+        "evidence_refs": release_gate_contract.output.evidence_refs,
+        "window_seconds": release_gate_contract.input.window_seconds,
+        "generated_at": release_gate_contract.input.generated_at,
+        "thresholds": release_gate_contract.input.thresholds,
+        "metrics": {
+            "replay_attempts_total": release_gate_contract.input.replay_attempts_total,
+            "replay_success_total": release_gate_contract.input.replay_success_total,
+            "replay_failure_total": release_gate_contract.input.replay_failure_total,
+            "replay_hit_rate": release_gate_contract.input.replay_hit_rate,
+            "false_replay_rate": release_gate_contract.input.false_replay_rate,
+            "reasoning_avoided_tokens": release_gate_contract.input.reasoning_avoided_tokens,
+            "replay_fallback_cost_total": release_gate_contract.input.replay_fallback_cost_total,
+            "replay_roi": release_gate_contract.input.replay_roi,
+            "replay_safety": release_gate_contract.input.replay_safety
+        }
+    });
+    if let Ok(path) = std::env::var("ORIS_RELEASE_GATE_EVIDENCE_OUT") {
+        let out_path = PathBuf::from(path);
+        write_json_value(&out_path, &release_gate_evidence);
+        append_audit_log(
+            &audit_log,
+            format!(
+                "[PASS] release gate evidence exported path={}",
+                out_path.display()
+            ),
+        );
+    }
     assert!(realtime_log_path.exists());
     assert!(realtime_jsonl_path.exists());
     assert_stub_realtime_logs(&realtime_jsonl_path);

--- a/docs/production-operations-guide.md
+++ b/docs/production-operations-guide.md
@@ -199,8 +199,12 @@ Required checklist:
 - contract gate: pass
 - e2e gate: pass
 - backend parity gate (sqlite/postgres): pass, or approved exception recorded
+- self-evolution release gate: pass (`release_gate_status == "pass"`)
 - evidence bundle id from `target/evomap-release-evidence.json` attached to the
   approval record
+- self-evolution evidence from
+  `target/evomap_release_gate/self_evolution_release_gate.json` attached to the
+  same approval record
 
 Do not publish if the release gate summary has `status != "pass"` unless an
 explicit exception is approved and logged with the same evidence bundle id.

--- a/scripts/run_evomap_release_gate.sh
+++ b/scripts/run_evomap_release_gate.sh
@@ -12,6 +12,10 @@ SNAPSHOT_DIFF_STATUS="not-run"
 SNAPSHOT_ADDED_COUNT=0
 SNAPSHOT_REMOVED_COUNT=0
 SNAPSHOT_CHANGED_COUNT=0
+RELEASE_GATE_EVIDENCE_FILE="${ARTIFACT_DIR}/self_evolution_release_gate.json"
+RELEASE_GATE_EVIDENCE_OUT_FILE="$(pwd)/${RELEASE_GATE_EVIDENCE_FILE}"
+RELEASE_GATE_STATUS="not-run"
+RELEASE_GATE_FAILED_CHECKS_COUNT=0
 
 mkdir -p "${ARTIFACT_DIR}"
 : > "${LOG_FILE}"
@@ -55,8 +59,36 @@ PY
   IFS='|' read -r SNAPSHOT_DIFF_STATUS SNAPSHOT_ADDED_COUNT SNAPSHOT_REMOVED_COUNT SNAPSHOT_CHANGED_COUNT <<< "${values}"
 }
 
+update_release_gate_metrics() {
+  if [[ ! -f "${RELEASE_GATE_EVIDENCE_OUT_FILE}" ]]; then
+    return 0
+  fi
+
+  local values
+  values="$(
+    python3 - "${RELEASE_GATE_EVIDENCE_OUT_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    payload = json.load(f)
+
+status = str(payload.get("status", "unknown"))
+failed_checks = payload.get("failed_checks")
+if not isinstance(failed_checks, list):
+    failed_checks = []
+
+print(f"{status}|{len(failed_checks)}")
+PY
+  )"
+
+  IFS='|' read -r RELEASE_GATE_STATUS RELEASE_GATE_FAILED_CHECKS_COUNT <<< "${values}"
+}
+
 write_summary() {
   update_snapshot_diff_metrics
+  update_release_gate_metrics
 
   local generated_at
   generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -74,7 +106,10 @@ write_summary() {
   "snapshot_diff_status": "${SNAPSHOT_DIFF_STATUS}",
   "snapshot_diff_added_count": ${SNAPSHOT_ADDED_COUNT},
   "snapshot_diff_removed_count": ${SNAPSHOT_REMOVED_COUNT},
-  "snapshot_diff_changed_count": ${SNAPSHOT_CHANGED_COUNT}
+  "snapshot_diff_changed_count": ${SNAPSHOT_CHANGED_COUNT},
+  "release_gate_evidence_file": "${RELEASE_GATE_EVIDENCE_OUT_FILE}",
+  "release_gate_status": "${RELEASE_GATE_STATUS}",
+  "release_gate_failed_checks_count": ${RELEASE_GATE_FAILED_CHECKS_COUNT}
 }
 JSON
 }
@@ -111,6 +146,34 @@ run_step "runtime-audit-core-actions" \
   cargo test -p oris-runtime --features "full-evolution-experimental execution-server sqlite-persistence" \
   execution_server::api_handlers::tests::audit_logs_capture_semantic_protocol_core_actions \
   -- --nocapture --test-threads=1
+
+run_step "runtime-self-evolution-release-gate" \
+  env ORIS_RELEASE_GATE_EVIDENCE_OUT="${RELEASE_GATE_EVIDENCE_OUT_FILE}" \
+  cargo test -p oris-runtime --test agent_self_evolution_travel_network \
+  --features full-evolution-experimental -- --nocapture
+
+run_step "runtime-self-evolution-release-gate-enforce-pass" \
+  python3 - "${RELEASE_GATE_EVIDENCE_OUT_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    payload = json.load(f)
+
+status = str(payload.get("status", "unknown"))
+if status != "pass":
+    failed_checks = payload.get("failed_checks")
+    if not isinstance(failed_checks, list):
+        failed_checks = []
+    summary = str(payload.get("summary", ""))
+    print(
+        f"[evomap-release-gate] release gate blocked publish status={status} "
+        f"failed_checks={failed_checks} summary={summary}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
 
 run_step "experience-snapshot-export" \
   python3 scripts/export_experience_assets_snapshot.py \


### PR DESCRIPTION
## Summary
- wire self-evolution release gate execution into scripts/run_evomap_release_gate.sh pre-release path
- run runtime travel-network gate scenario with ORIS_RELEASE_GATE_EVIDENCE_OUT and archive gate evidence JSON
- enforce hard block: release flow exits non-zero when gate status is not pass
- include release gate evidence path/status/failed-check count in target/evomap-release-evidence.json summary
- extend travel network integration test to export machine-readable gate evidence payload
- update production operations guide checklist with self-evolution gate evidence requirements

## Validation
- cargo fmt --all
- bash -n scripts/run_evomap_release_gate.sh
- cargo test -p oris-runtime --test agent_self_evolution_travel_network --features full-evolution-experimental -- --nocapture

Closes #214