### PR TITLE
[EVO26-W6-12][P1] Harden mutation-needed fail-closed path

### DIFF
--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -464,6 +464,93 @@ pub struct ReplayFeedback {
     pub summary: String,
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationNeededFailureReasonCode {
+    PolicyDenied,
+    ValidationFailed,
+    UnsafePatch,
+    Timeout,
+    MutationPayloadMissing,
+    UnknownFailClosed,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationNeededRecoveryAction {
+    NarrowScopeAndRetry,
+    RepairAndRevalidate,
+    ProduceSafePatch,
+    ReduceExecutionBudget,
+    RegenerateMutationPayload,
+    EscalateFailClosed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MutationNeededFailureContract {
+    pub reason_code: MutationNeededFailureReasonCode,
+    pub failure_reason: String,
+    pub recovery_hint: String,
+    pub recovery_action: MutationNeededRecoveryAction,
+    pub fail_closed: bool,
+}
+
+pub fn infer_mutation_needed_failure_reason_code(
+    reason: &str,
+) -> Option<MutationNeededFailureReasonCode> {
+    let normalized = reason.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.contains("mutation payload missing") || normalized == "mutation_payload_missing" {
+        return Some(MutationNeededFailureReasonCode::MutationPayloadMissing);
+    }
+    if normalized.contains("command timed out") || normalized.contains(" timeout") {
+        return Some(MutationNeededFailureReasonCode::Timeout);
+    }
+    if normalized.contains("patch rejected")
+        || normalized.contains("patch apply failed")
+        || normalized.contains("target violation")
+        || normalized.contains("unsafe patch")
+    {
+        return Some(MutationNeededFailureReasonCode::UnsafePatch);
+    }
+    if normalized.contains("validation failed") {
+        return Some(MutationNeededFailureReasonCode::ValidationFailed);
+    }
+    if normalized.contains("command denied by policy")
+        || normalized.contains("rejected task")
+        || normalized.contains("unsupported task outside the bounded scope")
+        || normalized.contains("budget exceeds bounded policy")
+    {
+        return Some(MutationNeededFailureReasonCode::PolicyDenied);
+    }
+    None
+}
+
+pub fn normalize_mutation_needed_failure_contract(
+    failure_reason: Option<&str>,
+    reason_code: Option<MutationNeededFailureReasonCode>,
+) -> MutationNeededFailureContract {
+    let normalized_reason = normalize_optional_text(failure_reason);
+    let resolved_reason_code = reason_code
+        .or_else(|| {
+            normalized_reason
+                .as_deref()
+                .and_then(infer_mutation_needed_failure_reason_code)
+        })
+        .unwrap_or(MutationNeededFailureReasonCode::UnknownFailClosed);
+    let defaults = mutation_needed_failure_defaults(&resolved_reason_code);
+
+    MutationNeededFailureContract {
+        reason_code: resolved_reason_code,
+        failure_reason: normalized_reason.unwrap_or_else(|| defaults.failure_reason.to_string()),
+        recovery_hint: defaults.recovery_hint.to_string(),
+        recovery_action: defaults.recovery_action,
+        fail_closed: true,
+    }
+}
+
 fn normalize_optional_text(value: Option<&str>) -> Option<String> {
     let trimmed = value?.trim();
     if trimmed.is_empty() {
@@ -532,6 +619,55 @@ fn replay_fallback_defaults(reason_code: &ReplayFallbackReasonCode) -> ReplayFal
     }
 }
 
+#[derive(Clone, Copy)]
+struct MutationNeededFailureDefaults {
+    failure_reason: &'static str,
+    recovery_hint: &'static str,
+    recovery_action: MutationNeededRecoveryAction,
+}
+
+fn mutation_needed_failure_defaults(
+    reason_code: &MutationNeededFailureReasonCode,
+) -> MutationNeededFailureDefaults {
+    match reason_code {
+        MutationNeededFailureReasonCode::PolicyDenied => MutationNeededFailureDefaults {
+            failure_reason: "mutation needed denied by bounded execution policy",
+            recovery_hint:
+                "Narrow changed scope to the approved docs boundary and re-run with explicit approval.",
+            recovery_action: MutationNeededRecoveryAction::NarrowScopeAndRetry,
+        },
+        MutationNeededFailureReasonCode::ValidationFailed => MutationNeededFailureDefaults {
+            failure_reason: "mutation needed validation failed",
+            recovery_hint:
+                "Repair mutation and re-run validation to produce a deterministic pass before capture.",
+            recovery_action: MutationNeededRecoveryAction::RepairAndRevalidate,
+        },
+        MutationNeededFailureReasonCode::UnsafePatch => MutationNeededFailureDefaults {
+            failure_reason: "mutation needed rejected unsafe patch",
+            recovery_hint:
+                "Generate a safer minimal diff confined to approved paths and verify patch applicability.",
+            recovery_action: MutationNeededRecoveryAction::ProduceSafePatch,
+        },
+        MutationNeededFailureReasonCode::Timeout => MutationNeededFailureDefaults {
+            failure_reason: "mutation needed execution timed out",
+            recovery_hint:
+                "Reduce execution budget or split the mutation into smaller steps before retrying.",
+            recovery_action: MutationNeededRecoveryAction::ReduceExecutionBudget,
+        },
+        MutationNeededFailureReasonCode::MutationPayloadMissing => MutationNeededFailureDefaults {
+            failure_reason: "mutation payload missing from store",
+            recovery_hint: "Regenerate and persist mutation payload before retrying mutation-needed.",
+            recovery_action: MutationNeededRecoveryAction::RegenerateMutationPayload,
+        },
+        MutationNeededFailureReasonCode::UnknownFailClosed => MutationNeededFailureDefaults {
+            failure_reason: "mutation needed failed with unmapped reason",
+            recovery_hint:
+                "Unknown failure class; fail closed and require explicit maintainer triage before retry.",
+            recovery_action: MutationNeededRecoveryAction::EscalateFailClosed,
+        },
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum BoundedTaskClass {
     DocsSingleFile,
@@ -555,6 +691,7 @@ pub struct SupervisedDevloopRequest {
 pub enum SupervisedDevloopStatus {
     AwaitingApproval,
     RejectedByPolicy,
+    FailedClosed,
     Executed,
 }
 
@@ -564,6 +701,8 @@ pub struct SupervisedDevloopOutcome {
     pub task_class: Option<BoundedTaskClass>,
     pub status: SupervisedDevloopStatus,
     pub execution_feedback: Option<ExecutionFeedback>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_contract: Option<MutationNeededFailureContract>,
     pub summary: String,
 }
 
@@ -679,6 +818,58 @@ mod tests {
             ReplayFallbackNextAction::EscalateFailClosed
         );
         assert_eq!(contract.confidence, 0);
+    }
+
+    #[test]
+    fn normalize_mutation_needed_failure_contract_maps_policy_denied() {
+        let contract = normalize_mutation_needed_failure_contract(
+            Some("supervised devloop rejected task because it is outside bounded scope"),
+            None,
+        );
+
+        assert_eq!(
+            contract.reason_code,
+            MutationNeededFailureReasonCode::PolicyDenied
+        );
+        assert_eq!(
+            contract.recovery_action,
+            MutationNeededRecoveryAction::NarrowScopeAndRetry
+        );
+        assert!(contract.fail_closed);
+    }
+
+    #[test]
+    fn normalize_mutation_needed_failure_contract_maps_timeout() {
+        let contract = normalize_mutation_needed_failure_contract(
+            Some("command timed out: git apply --check patch.diff"),
+            None,
+        );
+
+        assert_eq!(
+            contract.reason_code,
+            MutationNeededFailureReasonCode::Timeout
+        );
+        assert_eq!(
+            contract.recovery_action,
+            MutationNeededRecoveryAction::ReduceExecutionBudget
+        );
+        assert!(contract.fail_closed);
+    }
+
+    #[test]
+    fn normalize_mutation_needed_failure_contract_fails_closed_for_unknown_reason() {
+        let contract =
+            normalize_mutation_needed_failure_contract(Some("unexpected runner panic"), None);
+
+        assert_eq!(
+            contract.reason_code,
+            MutationNeededFailureReasonCode::UnknownFailClosed
+        );
+        assert_eq!(
+            contract.recovery_action,
+            MutationNeededRecoveryAction::EscalateFailClosed
+        );
+        assert!(contract.fail_closed);
     }
 }
 

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -9,11 +9,13 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
-    infer_replay_fallback_reason_code, normalize_replay_fallback_contract, AgentRole,
+    infer_mutation_needed_failure_reason_code, infer_replay_fallback_reason_code,
+    normalize_mutation_needed_failure_contract, normalize_replay_fallback_contract, AgentRole,
     BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
-    CoordinationResult, CoordinationTask, ExecutionFeedback,
-    MutationProposal as AgentMutationProposal, ReplayFeedback, ReplayPlannerDirective,
-    SupervisedDevloopOutcome, SupervisedDevloopRequest, SupervisedDevloopStatus,
+    CoordinationResult, CoordinationTask, ExecutionFeedback, MutationNeededFailureContract,
+    MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal, ReplayFeedback,
+    ReplayPlannerDirective, SupervisedDevloopOutcome, SupervisedDevloopRequest,
+    SupervisedDevloopStatus,
 };
 use oris_economics::{EconomicsSignal, EvuLedger, StakePolicy};
 use oris_evolution::{
@@ -170,6 +172,10 @@ const SHADOW_PROMOTION_MIN_DECAYED_CONFIDENCE: f32 = MIN_REPLAY_CONFIDENCE;
 const REPLAY_REASONING_TOKEN_FLOOR: u64 = 192;
 const REPLAY_REASONING_TOKEN_SIGNAL_WEIGHT: u64 = 24;
 const COLD_START_LOOKUP_PENALTY: f32 = 0.05;
+const MUTATION_NEEDED_MAX_DIFF_BYTES: usize = 128 * 1024;
+const MUTATION_NEEDED_MAX_CHANGED_LINES: usize = 600;
+const MUTATION_NEEDED_MAX_SANDBOX_DURATION_MS: u64 = 120_000;
+const MUTATION_NEEDED_MAX_VALIDATION_BUDGET_MS: u64 = 900_000;
 pub const REPLAY_RELEASE_GATE_AGGREGATION_DIMENSIONS: [&str; 2] =
     ["task_class", "source_sender_id"];
 
@@ -2306,13 +2312,20 @@ impl<S: KernelState> EvoKernel<S> {
         let receipt = match self.sandbox.apply(&mutation, &self.sandbox_policy).await {
             Ok(receipt) => receipt,
             Err(err) => {
+                let message = err.to_string();
+                let contract = mutation_needed_contract_for_error_message(&message);
                 self.store
                     .append_event(EvolutionEvent::MutationRejected {
                         mutation_id: mutation.intent.id.clone(),
-                        reason: err.to_string(),
+                        reason: contract.failure_reason,
+                        reason_code: Some(
+                            mutation_needed_reason_code_key(contract.reason_code).to_string(),
+                        ),
+                        recovery_hint: Some(contract.recovery_hint),
+                        fail_closed: contract.fail_closed,
                     })
                     .map_err(store_err)?;
-                return Err(EvoKernelError::Sandbox(err.to_string()));
+                return Err(EvoKernelError::Sandbox(message));
             }
         };
 
@@ -2328,17 +2341,46 @@ impl<S: KernelState> EvoKernel<S> {
             })
             .map_err(store_err)?;
 
-        let report = self
-            .validator
-            .run(&receipt, &self.validation_plan)
-            .await
-            .map_err(|err| EvoKernelError::Validation(err.to_string()))?;
+        let report = match self.validator.run(&receipt, &self.validation_plan).await {
+            Ok(report) => report,
+            Err(err) => {
+                let message = format!("mutation-needed validation execution error: {err}");
+                let contract = mutation_needed_contract_for_error_message(&message);
+                self.store
+                    .append_event(EvolutionEvent::MutationRejected {
+                        mutation_id: mutation.intent.id.clone(),
+                        reason: contract.failure_reason,
+                        reason_code: Some(
+                            mutation_needed_reason_code_key(contract.reason_code).to_string(),
+                        ),
+                        recovery_hint: Some(contract.recovery_hint),
+                        fail_closed: contract.fail_closed,
+                    })
+                    .map_err(store_err)?;
+                return Err(EvoKernelError::Validation(message));
+            }
+        };
         if !report.success {
             self.store
                 .append_event(EvolutionEvent::ValidationFailed {
                     mutation_id: mutation.intent.id.clone(),
                     report: report.to_snapshot(&self.validation_plan.profile),
                     gene_id: None,
+                })
+                .map_err(store_err)?;
+            let contract = mutation_needed_contract_for_validation_failure(
+                &self.validation_plan.profile,
+                &report,
+            );
+            self.store
+                .append_event(EvolutionEvent::MutationRejected {
+                    mutation_id: mutation.intent.id.clone(),
+                    reason: contract.failure_reason,
+                    reason_code: Some(
+                        mutation_needed_reason_code_key(contract.reason_code).to_string(),
+                    ),
+                    recovery_hint: Some(contract.recovery_hint),
+                    fail_closed: contract.fail_closed,
                 })
                 .map_err(store_err)?;
             return Err(EvoKernelError::ValidationFailed(report));
@@ -2577,6 +2619,48 @@ impl<S: KernelState> EvoKernel<S> {
             summary,
         }
     }
+
+    fn mutation_needed_failure_outcome(
+        &self,
+        request: &SupervisedDevloopRequest,
+        task_class: Option<BoundedTaskClass>,
+        status: SupervisedDevloopStatus,
+        contract: MutationNeededFailureContract,
+        mutation_id_for_audit: Option<String>,
+    ) -> Result<SupervisedDevloopOutcome, EvoKernelError> {
+        if let Some(mutation_id) = mutation_id_for_audit {
+            self.store
+                .append_event(EvolutionEvent::MutationRejected {
+                    mutation_id,
+                    reason: contract.failure_reason.clone(),
+                    reason_code: Some(
+                        mutation_needed_reason_code_key(contract.reason_code).to_string(),
+                    ),
+                    recovery_hint: Some(contract.recovery_hint.clone()),
+                    fail_closed: contract.fail_closed,
+                })
+                .map_err(store_err)?;
+        }
+        let status_label = match status {
+            SupervisedDevloopStatus::AwaitingApproval => "awaiting_approval",
+            SupervisedDevloopStatus::RejectedByPolicy => "rejected_by_policy",
+            SupervisedDevloopStatus::FailedClosed => "failed_closed",
+            SupervisedDevloopStatus::Executed => "executed",
+        };
+        let reason_code_key = mutation_needed_reason_code_key(contract.reason_code);
+        Ok(SupervisedDevloopOutcome {
+            task_id: request.task.id.clone(),
+            task_class,
+            status,
+            execution_feedback: None,
+            failure_contract: Some(contract.clone()),
+            summary: format!(
+                "supervised devloop {status_label} task '{}' [{reason_code_key}]: {}",
+                request.task.id, contract.failure_reason
+            ),
+        })
+    }
+
     pub async fn run_supervised_devloop(
         &self,
         run_id: &RunId,
@@ -2584,18 +2668,23 @@ impl<S: KernelState> EvoKernel<S> {
         diff_payload: String,
         base_revision: Option<String>,
     ) -> Result<SupervisedDevloopOutcome, EvoKernelError> {
+        let audit_mutation_id = mutation_needed_audit_mutation_id(request);
         let task_class = classify_supervised_devloop_request(request);
         let Some(task_class) = task_class else {
-            return Ok(SupervisedDevloopOutcome {
-                task_id: request.task.id.clone(),
-                task_class: None,
-                status: SupervisedDevloopStatus::RejectedByPolicy,
-                execution_feedback: None,
-                summary: format!(
+            let contract = normalize_mutation_needed_failure_contract(
+                Some(&format!(
                     "supervised devloop rejected task '{}' because it is an unsupported task outside the bounded scope",
                     request.task.id
-                ),
-            });
+                )),
+                Some(MutationNeededFailureReasonCode::PolicyDenied),
+            );
+            return self.mutation_needed_failure_outcome(
+                request,
+                None,
+                SupervisedDevloopStatus::RejectedByPolicy,
+                contract,
+                Some(audit_mutation_id),
+            );
         };
 
         if !request.approval.approved {
@@ -2604,6 +2693,7 @@ impl<S: KernelState> EvoKernel<S> {
                 task_class: Some(task_class),
                 status: SupervisedDevloopStatus::AwaitingApproval,
                 execution_feedback: None,
+                failure_contract: None,
                 summary: format!(
                     "supervised devloop paused task '{}' until explicit human approval is granted",
                     request.task.id
@@ -2611,9 +2701,123 @@ impl<S: KernelState> EvoKernel<S> {
             });
         }
 
-        let capture = self
+        if diff_payload.len() > MUTATION_NEEDED_MAX_DIFF_BYTES {
+            let contract = normalize_mutation_needed_failure_contract(
+                Some(&format!(
+                    "mutation-needed diff payload exceeds bounded byte budget (size={}, max={})",
+                    diff_payload.len(),
+                    MUTATION_NEEDED_MAX_DIFF_BYTES
+                )),
+                Some(MutationNeededFailureReasonCode::PolicyDenied),
+            );
+            return self.mutation_needed_failure_outcome(
+                request,
+                Some(task_class),
+                SupervisedDevloopStatus::RejectedByPolicy,
+                contract,
+                Some(audit_mutation_id),
+            );
+        }
+
+        let blast_radius = compute_blast_radius(&diff_payload);
+        if blast_radius.lines_changed > MUTATION_NEEDED_MAX_CHANGED_LINES {
+            let contract = normalize_mutation_needed_failure_contract(
+                Some(&format!(
+                    "mutation-needed patch exceeds bounded changed-line budget (lines_changed={}, max={})",
+                    blast_radius.lines_changed,
+                    MUTATION_NEEDED_MAX_CHANGED_LINES
+                )),
+                Some(MutationNeededFailureReasonCode::UnsafePatch),
+            );
+            return self.mutation_needed_failure_outcome(
+                request,
+                Some(task_class),
+                SupervisedDevloopStatus::FailedClosed,
+                contract,
+                Some(audit_mutation_id),
+            );
+        }
+
+        if self.sandbox_policy.max_duration_ms > MUTATION_NEEDED_MAX_SANDBOX_DURATION_MS {
+            let contract = normalize_mutation_needed_failure_contract(
+                Some(&format!(
+                    "mutation-needed sandbox duration budget exceeds bounded policy (configured={}ms, max={}ms)",
+                    self.sandbox_policy.max_duration_ms,
+                    MUTATION_NEEDED_MAX_SANDBOX_DURATION_MS
+                )),
+                Some(MutationNeededFailureReasonCode::PolicyDenied),
+            );
+            return self.mutation_needed_failure_outcome(
+                request,
+                Some(task_class),
+                SupervisedDevloopStatus::RejectedByPolicy,
+                contract,
+                Some(audit_mutation_id),
+            );
+        }
+
+        let validation_budget_ms = validation_plan_timeout_budget_ms(&self.validation_plan);
+        if validation_budget_ms > MUTATION_NEEDED_MAX_VALIDATION_BUDGET_MS {
+            let contract = normalize_mutation_needed_failure_contract(
+                Some(&format!(
+                    "mutation-needed validation timeout budget exceeds bounded policy (configured={}ms, max={}ms)",
+                    validation_budget_ms,
+                    MUTATION_NEEDED_MAX_VALIDATION_BUDGET_MS
+                )),
+                Some(MutationNeededFailureReasonCode::PolicyDenied),
+            );
+            return self.mutation_needed_failure_outcome(
+                request,
+                Some(task_class),
+                SupervisedDevloopStatus::RejectedByPolicy,
+                contract,
+                Some(audit_mutation_id),
+            );
+        }
+
+        let capture = match self
             .capture_from_proposal(run_id, &request.proposal, diff_payload, base_revision)
-            .await?;
+            .await
+        {
+            Ok(capture) => capture,
+            Err(EvoKernelError::Sandbox(message)) => {
+                let contract = mutation_needed_contract_for_error_message(&message);
+                let status = mutation_needed_status_from_reason_code(contract.reason_code);
+                return self.mutation_needed_failure_outcome(
+                    request,
+                    Some(task_class),
+                    status,
+                    contract,
+                    None,
+                );
+            }
+            Err(EvoKernelError::ValidationFailed(report)) => {
+                let contract = mutation_needed_contract_for_validation_failure(
+                    &self.validation_plan.profile,
+                    &report,
+                );
+                let status = mutation_needed_status_from_reason_code(contract.reason_code);
+                return self.mutation_needed_failure_outcome(
+                    request,
+                    Some(task_class),
+                    status,
+                    contract,
+                    None,
+                );
+            }
+            Err(EvoKernelError::Validation(message)) => {
+                let contract = mutation_needed_contract_for_error_message(&message);
+                let status = mutation_needed_status_from_reason_code(contract.reason_code);
+                return self.mutation_needed_failure_outcome(
+                    request,
+                    Some(task_class),
+                    status,
+                    contract,
+                    None,
+                );
+            }
+            Err(err) => return Err(err),
+        };
         let approver = request
             .approval
             .approver
@@ -2625,6 +2829,7 @@ impl<S: KernelState> EvoKernel<S> {
             task_class: Some(task_class),
             status: SupervisedDevloopStatus::Executed,
             execution_feedback: Some(Self::feedback_for_agent(&capture)),
+            failure_contract: None,
             summary: format!(
                 "supervised devloop executed task '{}' with explicit approval from {approver}",
                 request.task.id
@@ -3265,6 +3470,71 @@ fn is_rust_error_code(value: &str) -> bool {
     value.len() == 5
         && matches!(value.as_bytes().first(), Some(b'e') | Some(b'E'))
         && value[1..].chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn validation_plan_timeout_budget_ms(plan: &ValidationPlan) -> u64 {
+    plan.stages.iter().fold(0_u64, |acc, stage| match stage {
+        ValidationStage::Command { timeout_ms, .. } => acc.saturating_add(*timeout_ms),
+    })
+}
+
+fn mutation_needed_reason_code_key(reason_code: MutationNeededFailureReasonCode) -> &'static str {
+    match reason_code {
+        MutationNeededFailureReasonCode::PolicyDenied => "policy_denied",
+        MutationNeededFailureReasonCode::ValidationFailed => "validation_failed",
+        MutationNeededFailureReasonCode::UnsafePatch => "unsafe_patch",
+        MutationNeededFailureReasonCode::Timeout => "timeout",
+        MutationNeededFailureReasonCode::MutationPayloadMissing => "mutation_payload_missing",
+        MutationNeededFailureReasonCode::UnknownFailClosed => "unknown_fail_closed",
+    }
+}
+
+fn mutation_needed_status_from_reason_code(
+    reason_code: MutationNeededFailureReasonCode,
+) -> SupervisedDevloopStatus {
+    if matches!(reason_code, MutationNeededFailureReasonCode::PolicyDenied) {
+        SupervisedDevloopStatus::RejectedByPolicy
+    } else {
+        SupervisedDevloopStatus::FailedClosed
+    }
+}
+
+fn mutation_needed_contract_for_validation_failure(
+    profile: &str,
+    report: &ValidationReport,
+) -> MutationNeededFailureContract {
+    let lower_logs = report.logs.to_ascii_lowercase();
+    if lower_logs.contains("timed out") {
+        normalize_mutation_needed_failure_contract(
+            Some(&format!(
+                "mutation-needed validation command timed out under profile '{profile}'"
+            )),
+            Some(MutationNeededFailureReasonCode::Timeout),
+        )
+    } else {
+        normalize_mutation_needed_failure_contract(
+            Some(&format!(
+                "mutation-needed validation failed under profile '{profile}'"
+            )),
+            Some(MutationNeededFailureReasonCode::ValidationFailed),
+        )
+    }
+}
+
+fn mutation_needed_contract_for_error_message(message: &str) -> MutationNeededFailureContract {
+    let reason_code = infer_mutation_needed_failure_reason_code(message);
+    normalize_mutation_needed_failure_contract(Some(message), reason_code)
+}
+
+fn mutation_needed_audit_mutation_id(request: &SupervisedDevloopRequest) -> String {
+    stable_hash_json(&(
+        "mutation-needed-audit",
+        &request.task.id,
+        &request.proposal.intent,
+        &request.proposal.files,
+    ))
+    .map(|hash| format!("mutation-needed-{hash}"))
+    .unwrap_or_else(|_| format!("mutation-needed-{}", request.task.id))
 }
 
 fn classify_supervised_devloop_request(

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -10,9 +10,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{Duration, Utc};
 use oris_agent_contract::{
-    AgentTask, BoundedTaskClass, HumanApproval, MutationProposal, ReplayFallbackNextAction,
-    ReplayFallbackReasonCode, ReplayPlannerDirective, SupervisedDevloopRequest,
-    SupervisedDevloopStatus,
+    AgentTask, BoundedTaskClass, HumanApproval, MutationNeededFailureReasonCode, MutationProposal,
+    ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayPlannerDirective,
+    SupervisedDevloopRequest, SupervisedDevloopStatus,
 };
 use oris_evokernel::{
     extract_deterministic_signals, prepare_mutation, CommandValidator, EvoAssetState,
@@ -302,11 +302,19 @@ fn replay_input(signal: &str, workspace: &std::path::Path) -> EvoSelectorInput {
 }
 
 fn test_evo(label: &str) -> (PathBuf, Arc<JsonlEvolutionStore>, EvoKernel<TestState>) {
+    test_evo_with_policy_and_plan(label, sandbox_policy(), lightweight_plan())
+}
+
+fn test_evo_with_policy_and_plan(
+    label: &str,
+    policy: EvoSandboxPolicy,
+    plan: ValidationPlan,
+) -> (PathBuf, Arc<JsonlEvolutionStore>, EvoKernel<TestState>) {
     let workspace = temp_workspace();
     let sandbox_root = unique_path(&format!("{label}-sandbox"));
     let store_root = unique_path(&format!("{label}-store"));
     let store = Arc::new(JsonlEvolutionStore::new(&store_root));
-    let validator = Arc::new(CommandValidator::new(sandbox_policy()));
+    let validator = Arc::new(CommandValidator::new(policy.clone()));
     let sandbox = Arc::new(LocalProcessSandbox::new(
         format!("run-{label}"),
         &workspace,
@@ -317,8 +325,8 @@ fn test_evo(label: &str) -> (PathBuf, Arc<JsonlEvolutionStore>, EvoKernel<TestSt
             promote_after_successes: 1,
             ..Default::default()
         })))
-        .with_sandbox_policy(sandbox_policy())
-        .with_validation_plan(lightweight_plan());
+        .with_sandbox_policy(policy)
+        .with_validation_plan(plan);
     (workspace, store, evo)
 }
 
@@ -803,6 +811,7 @@ async fn supervised_devloop_executes_bounded_docs_task_after_approval() {
     assert_eq!(outcome.status, SupervisedDevloopStatus::Executed);
     assert_eq!(outcome.task_class, Some(BoundedTaskClass::DocsSingleFile));
     assert!(outcome.execution_feedback.is_some());
+    assert_eq!(outcome.failure_contract, None);
     assert!(outcome.summary.contains("executed"));
     assert!(store
         .scan(1)
@@ -831,6 +840,7 @@ async fn supervised_devloop_stops_before_execution_without_human_approval() {
     assert_eq!(outcome.status, SupervisedDevloopStatus::AwaitingApproval);
     assert_eq!(outcome.task_class, Some(BoundedTaskClass::DocsSingleFile));
     assert_eq!(outcome.execution_feedback, None);
+    assert_eq!(outcome.failure_contract, None);
     assert!(outcome.summary.contains("approval"));
     assert!(store.scan(1).unwrap().is_empty());
 }
@@ -856,8 +866,193 @@ async fn supervised_devloop_rejects_out_of_scope_tasks_without_bypassing_policy(
     assert_eq!(outcome.status, SupervisedDevloopStatus::RejectedByPolicy);
     assert_eq!(outcome.task_class, None);
     assert_eq!(outcome.execution_feedback, None);
+    assert_eq!(
+        outcome
+            .failure_contract
+            .as_ref()
+            .map(|contract| contract.reason_code),
+        Some(MutationNeededFailureReasonCode::PolicyDenied)
+    );
     assert!(outcome.summary.contains("unsupported"));
-    assert!(store.scan(1).unwrap().is_empty());
+    let events = store.scan(1).unwrap();
+    assert!(events.iter().any(|stored| matches!(
+        &stored.event,
+        EvolutionEvent::MutationRejected {
+            reason_code: Some(reason_code),
+            fail_closed,
+            ..
+        } if reason_code == "policy_denied" && *fail_closed
+    )));
+}
+
+#[tokio::test]
+async fn supervised_devloop_fails_closed_for_unsafe_patch_and_records_reason_code() {
+    let _audit = TestAuditGuard::new(
+        "supervised_devloop_fails_closed_for_unsafe_patch_and_records_reason_code",
+    );
+    let (_workspace, store, evo) = test_evo("supervised-devloop-unsafe-patch");
+    let request = devloop_request("task-docs-unsafe", "docs/supervised-unsafe.md", true);
+
+    let outcome = evo
+        .run_supervised_devloop(
+            &"run-supervised-devloop-unsafe".to_string(),
+            &request,
+            proposal_diff_for("src/lib.rs", "Unsafe Patch"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, SupervisedDevloopStatus::FailedClosed);
+    assert_eq!(
+        outcome
+            .failure_contract
+            .as_ref()
+            .map(|contract| contract.reason_code),
+        Some(MutationNeededFailureReasonCode::UnsafePatch)
+    );
+    assert!(outcome.summary.contains("unsafe_patch"));
+    assert!(store.scan(1).unwrap().iter().any(|stored| matches!(
+        &stored.event,
+        EvolutionEvent::MutationRejected {
+            reason_code: Some(reason_code),
+            fail_closed,
+            ..
+        } if reason_code == "unsafe_patch" && *fail_closed
+    )));
+}
+
+#[tokio::test]
+async fn supervised_devloop_fails_closed_on_validation_failure_with_recovery_contract() {
+    let _audit = TestAuditGuard::new(
+        "supervised_devloop_fails_closed_on_validation_failure_with_recovery_contract",
+    );
+    let (_workspace, store, evo) = test_evo_with_policy_and_plan(
+        "supervised-devloop-validation-fail",
+        sandbox_policy(),
+        failing_plan(),
+    );
+    let request = devloop_request("task-docs-validation-fail", "docs/supervised-fail.md", true);
+
+    let outcome = evo
+        .run_supervised_devloop(
+            &"run-supervised-devloop-validation-fail".to_string(),
+            &request,
+            proposal_diff_for("docs/supervised-fail.md", "Validation Fail"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, SupervisedDevloopStatus::FailedClosed);
+    let failure_contract = outcome.failure_contract.as_ref().expect("missing contract");
+    assert_eq!(
+        failure_contract.reason_code,
+        MutationNeededFailureReasonCode::ValidationFailed
+    );
+    assert!(failure_contract.recovery_hint.contains("Repair"));
+    let events = store.scan(1).unwrap();
+    assert!(events
+        .iter()
+        .any(|stored| matches!(&stored.event, EvolutionEvent::ValidationFailed { .. })));
+    assert!(events.iter().any(|stored| matches!(
+        &stored.event,
+        EvolutionEvent::MutationRejected {
+            reason_code: Some(reason_code),
+            fail_closed,
+            ..
+        } if reason_code == "validation_failed" && *fail_closed
+    )));
+}
+
+#[tokio::test]
+async fn supervised_devloop_rejects_validation_budget_over_limit_with_policy_reason() {
+    let _audit = TestAuditGuard::new(
+        "supervised_devloop_rejects_validation_budget_over_limit_with_policy_reason",
+    );
+    let over_budget_plan = ValidationPlan {
+        profile: "regression-over-budget".into(),
+        stages: vec![ValidationStage::Command {
+            program: "git".into(),
+            args: vec!["--version".into()],
+            timeout_ms: 900_001,
+        }],
+    };
+    let (_workspace, store, evo) = test_evo_with_policy_and_plan(
+        "supervised-devloop-budget-reject",
+        sandbox_policy(),
+        over_budget_plan,
+    );
+    let request = devloop_request("task-docs-budget-reject", "docs/supervised-budget.md", true);
+
+    let outcome = evo
+        .run_supervised_devloop(
+            &"run-supervised-devloop-budget-reject".to_string(),
+            &request,
+            proposal_diff_for("docs/supervised-budget.md", "Budget Reject"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, SupervisedDevloopStatus::RejectedByPolicy);
+    assert_eq!(
+        outcome
+            .failure_contract
+            .as_ref()
+            .map(|contract| contract.reason_code),
+        Some(MutationNeededFailureReasonCode::PolicyDenied)
+    );
+    assert!(store.scan(1).unwrap().iter().any(|stored| matches!(
+        &stored.event,
+        EvolutionEvent::MutationRejected {
+            reason_code: Some(reason_code),
+            fail_closed,
+            ..
+        } if reason_code == "policy_denied" && *fail_closed
+    )));
+}
+
+#[tokio::test]
+async fn supervised_devloop_fails_closed_on_timeout_with_consistent_reason_code() {
+    let _audit = TestAuditGuard::new(
+        "supervised_devloop_fails_closed_on_timeout_with_consistent_reason_code",
+    );
+    let mut timeout_policy = sandbox_policy();
+    timeout_policy.max_duration_ms = 0;
+    let (_workspace, store, evo) = test_evo_with_policy_and_plan(
+        "supervised-devloop-timeout",
+        timeout_policy,
+        lightweight_plan(),
+    );
+    let request = devloop_request("task-docs-timeout", "docs/supervised-timeout.md", true);
+
+    let outcome = evo
+        .run_supervised_devloop(
+            &"run-supervised-devloop-timeout".to_string(),
+            &request,
+            proposal_diff_for("docs/supervised-timeout.md", "Timeout"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, SupervisedDevloopStatus::FailedClosed);
+    assert_eq!(
+        outcome
+            .failure_contract
+            .as_ref()
+            .map(|contract| contract.reason_code),
+        Some(MutationNeededFailureReasonCode::Timeout)
+    );
+    assert!(store.scan(1).unwrap().iter().any(|stored| matches!(
+        &stored.event,
+        EvolutionEvent::MutationRejected {
+            reason_code: Some(reason_code),
+            fail_closed,
+            ..
+        } if reason_code == "timeout" && *fail_closed
+    )));
 }
 
 #[tokio::test]

--- a/crates/oris-evolution/src/core.rs
+++ b/crates/oris-evolution/src/core.rs
@@ -249,6 +249,12 @@ pub enum EvolutionEvent {
     MutationRejected {
         mutation_id: MutationId,
         reason: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason_code: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        recovery_hint: Option<String>,
+        #[serde(default)]
+        fail_closed: bool,
     },
     ValidationPassed {
         mutation_id: MutationId,
@@ -1082,6 +1088,9 @@ mod tests {
             .append_event(EvolutionEvent::MutationRejected {
                 mutation_id: "mutation-1".into(),
                 reason: "no-op".into(),
+                reason_code: None,
+                recovery_hint: None,
+                fail_closed: true,
             })
             .unwrap();
         assert_eq!(first, 1);

--- a/docs/evokernel/evolution.md
+++ b/docs/evokernel/evolution.md
@@ -232,18 +232,30 @@ Release gate evaluator output is deterministic and machine-readable:
 `evidence_refs` always points to metric or threshold dimensions used by each
 check.
 
-## 8.2 Supervised DEVLOOP (Bounded Scope)
+## 8.2 Supervised DEVLOOP (Bounded Scope + Fail-Closed Taxonomy)
 
-The checked-in runtime now exposes `run_supervised_devloop(...)` for one bounded
-task class: a single Markdown file under `docs/`. The flow stays policy-first:
+`run_supervised_devloop(...)` remains bounded to one task class (single
+Markdown file under `docs/`) and now enforces deterministic fail-closed
+constraints before execution:
 
-- classify the incoming proposal into the bounded scope
-- stop immediately if the proposal is outside that scope
-- stop at an explicit human approval boundary when approval is not granted
-- only then reuse the existing proposal capture and validation pipeline
+- reject out-of-scope proposals (`policy_denied`)
+- reject over-budget payload size / validation budget (`policy_denied`)
+- reject oversized or boundary-violating patch shapes (`unsafe_patch`)
+- fail closed on runtime timeout (`timeout`)
+- fail closed on validation failure (`validation_failed`)
 
-This keeps the DEVLOOP supervised and auditable while stopping short of
-autonomous branch, PR, or release behavior.
+The response now carries machine-readable failure metadata through
+`failure_contract`:
+
+- `reason_code`
+- `failure_reason`
+- `recovery_hint`
+- `recovery_action`
+- `fail_closed`
+
+For audit consistency, failure events are also recorded in
+`EvolutionEvent::MutationRejected` with the same `reason_code` and
+`recovery_hint`.
 
 ## 9. Evolution Store Requirements
 


### PR DESCRIPTION
## Summary
- harden run_supervised_devloop with bounded execution guardrails (diff size, changed-line cap, sandbox timeout cap, validation timeout budget cap)
- introduce machine-readable mutation-needed failure contract in agent API (reason_code, recovery_hint/action, fail_closed)
- unify fail-closed taxonomy across API and event audit stream for policy_denied, unsafe_patch, validation_failed, and timeout
- enrich EvolutionEvent::MutationRejected with reason_code/recovery_hint/fail_closed and emit consistently for sandbox and validation failures
- add supervised DEVLOOP regression coverage for policy denied / unsafe patch / validation failed / timeout plus docs update

## Validation
- cargo fmt --all
- cargo test -p oris-agent-contract
- cargo test -p oris-evolution
- cargo test -p oris-evokernel --test evolution_lifecycle_regression supervised_devloop_ -- --nocapture
- cargo test -p oris-evokernel --lib
- cargo test -p oris-runtime --test agent_self_evolution_travel_network --features full-evolution-experimental -- --nocapture

Closes #207
