### PR TITLE
feat: autonomous candidate intake from CI and runtime signals

### DIFF
--- a/RELEASE_v0.33.0.md
+++ b/RELEASE_v0.33.0.md
@@ -1,0 +1,65 @@
+# Release Notes — oris-runtime v0.33.0
+
+## Summary
+
+Implements **EVO26-AUTO-01**: Autonomous Candidate Intake From CI and Runtime Signals.
+
+This release adds the first machine-readable contract for discovering evolution
+candidates autonomously from CI and runtime diagnostic signals, without requiring
+a caller-supplied GitHub issue number.
+
+## Changes
+
+### New: Autonomous Intake Contract (`oris-agent-contract`)
+
+Five new public types:
+
+| Type | Purpose |
+|------|---------|
+| `AutonomousCandidateSource` | Signal source classification (`CiFailure`, `TestRegression`, `CompileRegression`, `LintRegression`, `RuntimeIncident`) |
+| `AutonomousIntakeReasonCode` | Outcome reason code (`Accepted`, `UnsupportedSignalClass`, `AmbiguousSignal`, `DuplicateCandidate`, `UnknownFailClosed`) |
+| `DiscoveredCandidate` | A single discovered candidate with `dedupe_key`, `candidate_source`, `candidate_class`, `signals`, `reason_code`, `fail_closed` |
+| `AutonomousIntakeInput` | Input to the intake method: `source_id`, `candidate_source`, `raw_signals` |
+| `AutonomousIntakeOutput` | Batch output: `candidates`, `accepted_count`, `denied_count` |
+
+Two new helper constructors:
+
+- `accept_discovered_candidate(dedupe_key, source, class, signals, summary)` → `DiscoveredCandidate`
+- `deny_discovered_candidate(dedupe_key, source, signals, reason_code)` → `DiscoveredCandidate`
+
+### New: `EvoKernel::discover_autonomous_candidates` (`oris-evokernel`)
+
+New method on `EvoKernel<S>`:
+
+```rust
+pub fn discover_autonomous_candidates(
+    &self,
+    input: &AutonomousIntakeInput,
+) -> AutonomousIntakeOutput
+```
+
+Behavior:
+- Normalises raw signals (trim, lowercase, sort, dedup)
+- Computes a stable `dedupe_key` via `stable_hash_json`
+- Checks for duplicate candidates in the evolution store (via `SignalsExtracted` events)
+- Maps signal source to `BoundedTaskClass` (`LintFix` for compile/test/lint/CI; `None` for `RuntimeIncident`)
+- Fail-closes on empty signals, ambiguous sources, or unknown outcomes
+- Does **not** generate mutation proposals, trigger task planning, or run executors
+
+### Validation
+
+- `cargo test -p oris-evokernel --test evolution_lifecycle_regression autonomous_intake_` — 5 new tests, all passing
+- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental` — 4 tests, all passing
+- `cargo build --all --release --all-features` — clean build
+- `cargo test --release --all-features` — no failures
+
+## Non-Goals (not included in this release)
+
+- Mutation proposal generation from discovered candidates
+- Autonomous execution or task planning
+- PR/release automation triggered by intake
+- Recovery or incident escalation beyond fail-closed signaling
+
+## Upgrade Notes
+
+No breaking changes. New types are additive. Existing `select_self_evolution_candidate` and `prepare_self_evolution_mutation_proposal` are unchanged.

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -744,6 +744,74 @@ pub struct SelfEvolutionCandidateIntakeRequest {
     pub candidate_hint_paths: Vec<String>,
 }
 
+/// Signal source for an autonomously discovered candidate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousCandidateSource {
+    CiFailure,
+    TestRegression,
+    CompileRegression,
+    LintRegression,
+    RuntimeIncident,
+}
+
+/// Reason code for the outcome of autonomous candidate classification.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousIntakeReasonCode {
+    Accepted,
+    UnsupportedSignalClass,
+    AmbiguousSignal,
+    DuplicateCandidate,
+    UnknownFailClosed,
+}
+
+/// A candidate discovered autonomously from CI or runtime signals without
+/// a caller-supplied issue number.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiscoveredCandidate {
+    /// Stable identity hash, deterministic for the same raw signals.
+    pub dedupe_key: String,
+    /// Classified signal source.
+    pub candidate_source: AutonomousCandidateSource,
+    /// Normalised candidate class (reuses `BoundedTaskClass`).
+    pub candidate_class: Option<BoundedTaskClass>,
+    /// Normalised signal tokens used as the discovered work description.
+    pub signals: Vec<String>,
+    /// Whether this candidate was accepted for further work.
+    pub accepted: bool,
+    /// Outcome reason code.
+    pub reason_code: AutonomousIntakeReasonCode,
+    /// Human-readable summary.
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_hint: Option<String>,
+    /// Fail-closed flag: true on any non-accepted outcome.
+    pub fail_closed: bool,
+}
+
+/// Input for autonomous candidate discovery from raw diagnostic output.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousIntakeInput {
+    /// Raw source identifier (e.g. CI run ID, log stream name).
+    pub source_id: String,
+    /// Classified origin of the raw signals.
+    pub candidate_source: AutonomousCandidateSource,
+    /// Raw text lines from diagnostics, test output, or incident logs.
+    pub raw_signals: Vec<String>,
+}
+
+/// Output of autonomous candidate intake: one or more discovered candidates
+/// (deduplicated) plus any that were denied with fail-closed reason codes.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousIntakeOutput {
+    pub candidates: Vec<DiscoveredCandidate>,
+    pub accepted_count: usize,
+    pub denied_count: usize,
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SelfEvolutionSelectionReasonCode {
@@ -880,6 +948,73 @@ pub fn reject_self_evolution_selection_decision(
         reason_code: Some(reason_code),
         failure_reason: Some(failure_reason),
         recovery_hint: Some(defaults.recovery_hint.to_string()),
+        fail_closed: true,
+    }
+}
+
+pub fn accept_discovered_candidate(
+    dedupe_key: impl Into<String>,
+    candidate_source: AutonomousCandidateSource,
+    candidate_class: BoundedTaskClass,
+    signals: Vec<String>,
+    summary: Option<&str>,
+) -> DiscoveredCandidate {
+    let summary = normalize_optional_text(summary)
+        .unwrap_or_else(|| format!("accepted autonomous candidate from {candidate_source:?}"));
+    DiscoveredCandidate {
+        dedupe_key: dedupe_key.into(),
+        candidate_source,
+        candidate_class: Some(candidate_class),
+        signals,
+        accepted: true,
+        reason_code: AutonomousIntakeReasonCode::Accepted,
+        summary,
+        failure_reason: None,
+        recovery_hint: None,
+        fail_closed: false,
+    }
+}
+
+pub fn deny_discovered_candidate(
+    dedupe_key: impl Into<String>,
+    candidate_source: AutonomousCandidateSource,
+    signals: Vec<String>,
+    reason_code: AutonomousIntakeReasonCode,
+) -> DiscoveredCandidate {
+    let (failure_reason, recovery_hint) = match reason_code {
+        AutonomousIntakeReasonCode::UnsupportedSignalClass => (
+            "signal class is not supported by the bounded evolution policy",
+            "review supported candidate signal classes and filter input before retry",
+        ),
+        AutonomousIntakeReasonCode::AmbiguousSignal => (
+            "signals do not map to a unique bounded candidate class",
+            "provide more specific signal tokens or triage manually before resubmitting",
+        ),
+        AutonomousIntakeReasonCode::DuplicateCandidate => (
+            "an equivalent candidate has already been discovered in this intake window",
+            "deduplicate signals before resubmitting or check the existing candidate queue",
+        ),
+        AutonomousIntakeReasonCode::UnknownFailClosed => (
+            "candidate intake failed with an unmapped reason; fail closed",
+            "require explicit maintainer triage before retry",
+        ),
+        AutonomousIntakeReasonCode::Accepted => (
+            "unexpected accepted reason on deny path",
+            "use accept_discovered_candidate for accepted outcomes",
+        ),
+    };
+    let summary =
+        format!("denied autonomous candidate from {candidate_source:?}: {failure_reason}");
+    DiscoveredCandidate {
+        dedupe_key: dedupe_key.into(),
+        candidate_source,
+        candidate_class: None,
+        signals,
+        accepted: false,
+        reason_code,
+        summary,
+        failure_reason: Some(failure_reason.to_string()),
+        recovery_hint: Some(recovery_hint.to_string()),
         fail_closed: true,
     }
 }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -9,15 +9,18 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
-    accept_self_evolution_selection_decision, infer_mutation_needed_failure_reason_code,
+    accept_discovered_candidate, accept_self_evolution_selection_decision,
+    deny_discovered_candidate, infer_mutation_needed_failure_reason_code,
     infer_replay_fallback_reason_code, normalize_mutation_needed_failure_contract,
     normalize_replay_fallback_contract, reject_self_evolution_selection_decision, AgentRole,
-    BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
-    CoordinationResult, CoordinationTask, ExecutionFeedback, MutationNeededFailureContract,
-    MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal,
-    MutationProposalContractReasonCode, MutationProposalEvidence, MutationProposalScope,
-    MutationProposalValidationBudget, ReplayFallbackReasonCode, ReplayFeedback,
-    ReplayPlannerDirective, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
+    AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeOutput,
+    AutonomousIntakeReasonCode, BoundedTaskClass, CoordinationMessage, CoordinationPlan,
+    CoordinationPrimitive, CoordinationResult, CoordinationTask, ExecutionFeedback,
+    MutationNeededFailureContract, MutationNeededFailureReasonCode,
+    MutationProposal as AgentMutationProposal, MutationProposalContractReasonCode,
+    MutationProposalEvidence, MutationProposalScope, MutationProposalValidationBudget,
+    ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
+    SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
     SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
     SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
@@ -3417,6 +3420,85 @@ impl<S: KernelState> EvoKernel<S> {
         )))
     }
 
+    /// Autonomous candidate intake: classify raw diagnostic signals without a
+    /// caller‐supplied issue number, deduplicate across the batch, and return
+    /// an [`AutonomousIntakeOutput`] with accepted and denied candidates.
+    ///
+    /// This is the entry point for `EVO26-AUTO-01` — it does **not** generate
+    /// mutation proposals or trigger any task planning.
+    pub fn discover_autonomous_candidates(
+        &self,
+        input: &AutonomousIntakeInput,
+    ) -> AutonomousIntakeOutput {
+        if input.raw_signals.is_empty() {
+            let deny = deny_discovered_candidate(
+                autonomous_dedupe_key(input.candidate_source, &input.raw_signals),
+                input.candidate_source,
+                Vec::new(),
+                AutonomousIntakeReasonCode::UnknownFailClosed,
+            );
+            return AutonomousIntakeOutput {
+                candidates: vec![deny],
+                accepted_count: 0,
+                denied_count: 1,
+            };
+        }
+
+        let normalized = normalize_autonomous_signals(&input.raw_signals);
+        let dedupe_key = autonomous_dedupe_key(input.candidate_source, &normalized);
+
+        // Check for a duplicate inside the active evolution store window.
+        if autonomous_is_duplicate_in_store(&self.store, &dedupe_key) {
+            let deny = deny_discovered_candidate(
+                dedupe_key,
+                input.candidate_source,
+                normalized,
+                AutonomousIntakeReasonCode::DuplicateCandidate,
+            );
+            return AutonomousIntakeOutput {
+                candidates: vec![deny],
+                accepted_count: 0,
+                denied_count: 1,
+            };
+        }
+
+        let Some(candidate_class) =
+            classify_autonomous_signals(input.candidate_source, &normalized)
+        else {
+            let reason = if normalized.is_empty() {
+                AutonomousIntakeReasonCode::UnknownFailClosed
+            } else {
+                AutonomousIntakeReasonCode::AmbiguousSignal
+            };
+            let deny =
+                deny_discovered_candidate(dedupe_key, input.candidate_source, normalized, reason);
+            return AutonomousIntakeOutput {
+                candidates: vec![deny],
+                accepted_count: 0,
+                denied_count: 1,
+            };
+        };
+
+        let summary = format!(
+            "autonomous candidate from {:?} ({:?}): {} signal(s)",
+            input.candidate_source,
+            candidate_class,
+            normalized.len()
+        );
+        let candidate = accept_discovered_candidate(
+            dedupe_key,
+            input.candidate_source,
+            candidate_class,
+            normalized,
+            Some(&summary),
+        );
+        AutonomousIntakeOutput {
+            accepted_count: 1,
+            denied_count: 0,
+            candidates: vec![candidate],
+        }
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5165,6 +5247,67 @@ fn normalized_selection_labels(labels: &[String]) -> BTreeSet<String> {
         .map(|label| label.trim().to_ascii_lowercase())
         .filter(|label| !label.is_empty())
         .collect()
+}
+
+/// Normalise raw signal tokens: trim, lowercase, remove empties, sort, dedup.
+fn normalize_autonomous_signals(raw: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = raw
+        .iter()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Compute a deterministic dedupe key from the signal source + normalised signal tokens.
+fn autonomous_dedupe_key(source: AutonomousCandidateSource, signals: &[String]) -> String {
+    stable_hash_json(&(source, signals))
+        .unwrap_or_else(|_| compute_artifact_hash(&format!("{source:?}{}", signals.join("|"))))
+}
+
+/// Map signal source + tokens to a `BoundedTaskClass`, or `None` when ambiguous / unsupported.
+fn classify_autonomous_signals(
+    source: AutonomousCandidateSource,
+    signals: &[String],
+) -> Option<BoundedTaskClass> {
+    use AutonomousCandidateSource::*;
+    match source {
+        CompileRegression | TestRegression | CiFailure => {
+            // A non‑empty normalised signal set from a compile/test CI source maps to LintFix
+            // (the narrowest bounded class that covers both lint and compile‑error remediation).
+            if signals.is_empty() {
+                None
+            } else {
+                Some(BoundedTaskClass::LintFix)
+            }
+        }
+        LintRegression => {
+            if signals.is_empty() {
+                None
+            } else {
+                Some(BoundedTaskClass::LintFix)
+            }
+        }
+        RuntimeIncident => None, // Incidents are not yet mapped to a bounded class.
+    }
+}
+
+/// Return `true` if an equivalent candidate (same dedupe key) already exists in the store
+/// by matching against previously extracted signal hashes.
+fn autonomous_is_duplicate_in_store(store: &Arc<dyn EvolutionStore>, dedupe_key: &str) -> bool {
+    let Ok(events) = store.scan(0) else {
+        return false;
+    };
+    for stored in events {
+        if let EvolutionEvent::SignalsExtracted { hash, .. } = &stored.event {
+            if hash == dedupe_key {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn find_declared_mutation(

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -10,7 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{Duration, Utc};
 use oris_agent_contract::{
-    AgentTask, BoundedTaskClass, HumanApproval, MutationNeededFailureReasonCode, MutationProposal,
+    AgentTask, AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeReasonCode,
+    BoundedTaskClass, HumanApproval, MutationNeededFailureReasonCode, MutationProposal,
     MutationProposalContractReasonCode, MutationProposalEvidence, ReplayFallbackNextAction,
     ReplayFallbackReasonCode, ReplayPlannerDirective, SelfEvolutionAcceptanceGateInput,
     SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionAuditConsistencyResult,
@@ -3489,4 +3490,140 @@ fn builtin_evomap_replay_path_has_declared_mutation() {
             )
         }));
     }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EVO26-AUTO-01: autonomous candidate intake regression tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn make_evo_kernel_for_autonomous_intake(label: &str) -> EvoKernel<TestState> {
+    let (_, _, evo) = test_evo(label);
+    evo
+}
+
+#[test]
+fn autonomous_intake_accepts_compile_regression_signal() {
+    let kernel = make_evo_kernel_for_autonomous_intake(
+        "autonomous_intake_accepts_compile_regression_signal",
+    );
+    let input = AutonomousIntakeInput {
+        source_id: "ci-run-001".to_string(),
+        candidate_source: AutonomousCandidateSource::CompileRegression,
+        raw_signals: vec![
+            "error[E0308]: mismatched types".to_string(),
+            "  --> crates/oris-runtime/src/lib.rs:42:5".to_string(),
+        ],
+    };
+
+    let output = kernel.discover_autonomous_candidates(&input);
+    assert_eq!(output.accepted_count, 1, "expected one accepted candidate");
+    assert_eq!(output.denied_count, 0);
+    let candidate = &output.candidates[0];
+    assert!(candidate.accepted, "candidate should be accepted");
+    assert_eq!(candidate.reason_code, AutonomousIntakeReasonCode::Accepted);
+    assert!(!candidate.fail_closed);
+    assert_eq!(candidate.candidate_class, Some(BoundedTaskClass::LintFix));
+    assert!(!candidate.dedupe_key.is_empty());
+}
+
+#[test]
+fn autonomous_intake_accepts_test_failure_signal() {
+    let kernel =
+        make_evo_kernel_for_autonomous_intake("autonomous_intake_accepts_test_failure_signal");
+    let input = AutonomousIntakeInput {
+        source_id: "ci-run-002".to_string(),
+        candidate_source: AutonomousCandidateSource::TestRegression,
+        raw_signals: vec![
+            "test evolution_lifecycle_regression::some_test ... FAILED".to_string(),
+            "failures: evolution_lifecycle_regression::some_test".to_string(),
+        ],
+    };
+
+    let output = kernel.discover_autonomous_candidates(&input);
+    assert_eq!(output.accepted_count, 1);
+    let candidate = &output.candidates[0];
+    assert!(candidate.accepted);
+    assert_eq!(candidate.candidate_class, Some(BoundedTaskClass::LintFix));
+}
+
+#[test]
+fn autonomous_intake_deduplicates_equivalent_signals() {
+    let kernel =
+        make_evo_kernel_for_autonomous_intake("autonomous_intake_deduplicates_equivalent_signals");
+    let signals = vec![
+        "  error[E0308]: mismatched types  ".to_string(), // extra whitespace
+        "error[E0308]: mismatched types".to_string(),     // duplicate after trim
+    ];
+    let input = AutonomousIntakeInput {
+        source_id: "ci-run-003".to_string(),
+        candidate_source: AutonomousCandidateSource::LintRegression,
+        raw_signals: signals,
+    };
+
+    let output = kernel.discover_autonomous_candidates(&input);
+    // After normalisation the two tokens collapse into one; still accepted.
+    assert_eq!(
+        output.accepted_count, 1,
+        "deduplicated signals still accepted"
+    );
+    assert_eq!(output.candidates.len(), 1);
+    // Normalised signals should have no duplicates.
+    let cand = &output.candidates[0];
+    let mut seen = std::collections::BTreeSet::new();
+    for s in &cand.signals {
+        assert!(
+            seen.insert(s.clone()),
+            "signal {s:?} appears twice after dedupe"
+        );
+    }
+}
+
+#[test]
+fn autonomous_intake_denies_empty_signals_fail_closed() {
+    let kernel =
+        make_evo_kernel_for_autonomous_intake("autonomous_intake_denies_empty_signals_fail_closed");
+    let input = AutonomousIntakeInput {
+        source_id: "ci-run-empty".to_string(),
+        candidate_source: AutonomousCandidateSource::CiFailure,
+        raw_signals: vec![],
+    };
+
+    let output = kernel.discover_autonomous_candidates(&input);
+    assert_eq!(output.accepted_count, 0);
+    assert_eq!(output.denied_count, 1);
+    let candidate = &output.candidates[0];
+    assert!(!candidate.accepted);
+    assert!(candidate.fail_closed, "empty signals must fail closed");
+    assert_eq!(
+        candidate.reason_code,
+        AutonomousIntakeReasonCode::UnknownFailClosed
+    );
+}
+
+#[test]
+fn autonomous_intake_denies_ambiguous_signals_fail_closed() {
+    let kernel = make_evo_kernel_for_autonomous_intake(
+        "autonomous_intake_denies_ambiguous_signals_fail_closed",
+    );
+    // RuntimeIncident is currently unsupported / maps to None in classify_autonomous_signals.
+    let input = AutonomousIntakeInput {
+        source_id: "incident-001".to_string(),
+        candidate_source: AutonomousCandidateSource::RuntimeIncident,
+        raw_signals: vec![
+            "PANIC: index out of bounds".to_string(),
+            "thread 'tokio-worker' panicked".to_string(),
+        ],
+    };
+
+    let output = kernel.discover_autonomous_candidates(&input);
+    assert_eq!(output.accepted_count, 0);
+    assert_eq!(output.denied_count, 1);
+    let candidate = &output.candidates[0];
+    assert!(!candidate.accepted);
+    assert!(candidate.fail_closed, "unsupported source must fail closed");
+    assert_eq!(
+        candidate.reason_code,
+        AutonomousIntakeReasonCode::AmbiguousSignal
+    );
+    assert!(candidate.candidate_class.is_none());
 }

--- a/crates/oris-evolution/src/pipeline.rs
+++ b/crates/oris-evolution/src/pipeline.rs
@@ -1259,9 +1259,7 @@ mod tests {
                 validate_calls.clone(),
                 true,
             )))
-            .with_evaluate_port(Arc::new(CountingEvaluatePort::new(
-                evaluate_calls.clone(),
-            )));
+            .with_evaluate_port(Arc::new(CountingEvaluatePort::new(evaluate_calls.clone())));
 
         let result = pipeline
             .execute(PipelineContext::default())
@@ -1302,9 +1300,7 @@ mod tests {
                 validate_calls.clone(),
                 false,
             )))
-            .with_evaluate_port(Arc::new(CountingEvaluatePort::new(
-                evaluate_calls.clone(),
-            )));
+            .with_evaluate_port(Arc::new(CountingEvaluatePort::new(evaluate_calls.clone())));
 
         let result = pipeline
             .execute(PipelineContext::default())

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.32.2"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -218,3 +218,34 @@ fn task_class_resolver_paths_resolve() {
         &classes
     ));
 }
+
+/// Issue #264 — EVO26-AUTO-01: Autonomous candidate intake types resolve via facade
+#[test]
+fn autonomous_candidate_intake_types_resolve() {
+    assert_type::<oris_runtime::agent_contract::AutonomousCandidateSource>();
+    assert_type::<oris_runtime::agent_contract::AutonomousIntakeReasonCode>();
+    assert_type::<oris_runtime::agent_contract::DiscoveredCandidate>();
+    assert_type::<oris_runtime::agent_contract::AutonomousIntakeInput>();
+    assert_type::<oris_runtime::agent_contract::AutonomousIntakeOutput>();
+
+    // Constructor helpers resolve and produce correct types
+    let _c: oris_runtime::agent_contract::DiscoveredCandidate =
+        oris_runtime::agent_contract::accept_discovered_candidate(
+            "key1".to_string(),
+            oris_runtime::agent_contract::AutonomousCandidateSource::CiFailure,
+            oris_runtime::agent_contract::BoundedTaskClass::LintFix,
+            vec![],
+            None,
+        );
+    let _d: oris_runtime::agent_contract::DiscoveredCandidate =
+        oris_runtime::agent_contract::deny_discovered_candidate(
+            "key2".to_string(),
+            oris_runtime::agent_contract::AutonomousCandidateSource::CiFailure,
+            vec![],
+            oris_runtime::agent_contract::AutonomousIntakeReasonCode::UnknownFailClosed,
+        );
+
+    // Variants accessible
+    let _src = oris_runtime::agent_contract::AutonomousCandidateSource::CiFailure;
+    let _code = oris_runtime::agent_contract::AutonomousIntakeReasonCode::Accepted;
+}


### PR DESCRIPTION
Closes #264

## Summary
Adds EVO26-AUTO-01 autonomous candidate intake: EvoKernel discovers evolution candidates from CI/runtime signals without a caller-supplied issue number. Includes stable dedupe-key computation, bounded class mapping, and fail-closed policy.

## Validation
- cargo fmt --all check: passed
- autonomous_intake_ regression tests: 5/5 passed
- evolution_feature_wiring full-evolution-experimental: 4/4 passed
- cargo build --all --release --all-features: clean
- cargo test --release --all-features: no failures
- cargo publish dry-run: passed
- Released as oris-runtime v0.33.0
