### PR TITLE
feat(auto-03): autonomous mutation proposal contracts (#266)

### DIFF
--- a/RELEASE_v0.35.0.md
+++ b/RELEASE_v0.35.0.md
@@ -1,0 +1,45 @@
+# Release v0.35.0
+
+## oris-runtime v0.35.0
+
+### Summary
+
+Implements **AUTO-03: Autonomous Mutation Proposal Contracts** (Issue #266).
+
+Adds the typed contract layer for autonomous mutation proposals, allowing the EvoKernel to produce structured `AutonomousMutationProposal` values with deterministic approval-mode routing (auto-approved vs. human-review) based on per-class risk tier.
+
+### New Types (`oris-agent-contract`)
+
+- `AutonomousApprovalMode` — `AutoApproved` | `RequiresHumanReview`
+- `AutonomousProposalReasonCode` — `Proposed`, `DeniedPlanNotApproved`, `DeniedNoTargetScope`, `DeniedWeakEvidence`, `DeniedOutOfBounds`, `UnknownFailClosed`
+- `AutonomousProposalScope` — `target_paths: Vec<String>`, `scope_rationale: String`, `max_files: u8`
+- `AutonomousMutationProposal` — full proposal struct with `proposal_id`, `plan_id`, `dedupe_key`, `scope`, `expected_evidence`, `rollback_conditions`, `approval_mode`, `proposed`, `reason_code`, `summary`, `denial_condition`, `fail_closed`
+- `approve_autonomous_mutation_proposal()` — constructor for an approved proposal
+- `deny_autonomous_mutation_proposal()` — constructor for a denied proposal
+
+### New Method (`oris-evokernel`)
+
+- `EvoKernel::propose_autonomous_mutation(plan: &AutonomousTaskPlan) -> AutonomousMutationProposal`
+  - Returns `AutoApproved` for `AutonomousRiskTier::Low` task classes
+  - Returns `RequiresHumanReview` for `Medium`/`High` risk tier task classes
+  - Denies with `DeniedPlanNotApproved` if the plan is not approved
+  - Denies with `DeniedNoTargetScope` if the task class is unknown
+  - All denials set `fail_closed = true`
+
+### Risk-to-Approval Policy
+
+| `BoundedTaskClass`  | `AutonomousRiskTier` | `AutonomousApprovalMode` |
+|---------------------|----------------------|--------------------------|
+| `LintFix`           | Low                  | `AutoApproved`           |
+| `DocsSingleFile`    | Low                  | `AutoApproved`           |
+| `DocsMultiFile`     | Medium               | `RequiresHumanReview`    |
+| `CargoDepUpgrade`   | Medium               | `RequiresHumanReview`    |
+
+### Tests
+
+- 5 regression tests (`autonomous_proposal_*`) in `evolution_lifecycle_regression.rs`
+- 1 wiring gate test `autonomous_mutation_proposal_types_resolve` in `evolution_feature_wiring.rs`
+
+### Closes
+
+- Issue #266 (AUTO-03)

--- a/crates/oris-agent-contract/Cargo.toml
+++ b/crates/oris-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-agent-contract"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -958,6 +958,163 @@ pub fn deny_autonomous_task_plan(
     }
 }
 
+// ── AUTO-03: Autonomous mutation proposal contracts ───────────────────────────
+
+/// Approval mode for an autonomous mutation proposal.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousApprovalMode {
+    /// Proposal is self-approved within bounded policy; no human gate required.
+    AutoApproved,
+    /// Proposal requires explicit human review before execution.
+    RequiresHumanReview,
+}
+
+/// Stable reason code for an autonomous mutation proposal outcome.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousProposalReasonCode {
+    Proposed,
+    DeniedPlanNotApproved,
+    DeniedNoTargetScope,
+    DeniedWeakEvidence,
+    DeniedOutOfBounds,
+    UnknownFailClosed,
+}
+
+/// Bounded file scope for an autonomous mutation proposal.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousProposalScope {
+    /// Target files or paths that may be mutated.
+    pub target_paths: Vec<String>,
+    /// Human-readable rationale for why these targets are in scope.
+    pub scope_rationale: String,
+    /// Maximum number of files that may be changed in this proposal.
+    pub max_files: u8,
+}
+
+/// A machine-readable mutation proposal generated from an approved autonomous plan.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousMutationProposal {
+    /// Stable proposal identity hash.
+    pub proposal_id: String,
+    /// Matches `AutonomousTaskPlan.plan_id`.
+    pub plan_id: String,
+    /// Matches `AutonomousTaskPlan.dedupe_key`.
+    pub dedupe_key: String,
+    /// Bounded file scope for this mutation.
+    pub scope: Option<AutonomousProposalScope>,
+    /// Expected evidence templates (cargo commands, lint, tests, etc.).
+    pub expected_evidence: Vec<String>,
+    /// Conditions under which the mutation must be rolled back.
+    pub rollback_conditions: Vec<String>,
+    /// Approval mode for this proposal.
+    pub approval_mode: AutonomousApprovalMode,
+    /// Whether this proposal was successfully generated.
+    pub proposed: bool,
+    /// Stable outcome reason code.
+    pub reason_code: AutonomousProposalReasonCode,
+    /// Human-readable summary.
+    pub summary: String,
+    /// Structured denial information, populated when `proposed` is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub denial_condition: Option<AutonomousDenialCondition>,
+    /// True on any non-proposed outcome — enforces fail-closed semantics.
+    pub fail_closed: bool,
+}
+
+/// Construct an approved `AutonomousMutationProposal` from a valid plan.
+pub fn approve_autonomous_mutation_proposal(
+    proposal_id: impl Into<String>,
+    plan_id: impl Into<String>,
+    dedupe_key: impl Into<String>,
+    scope: AutonomousProposalScope,
+    expected_evidence: Vec<String>,
+    rollback_conditions: Vec<String>,
+    approval_mode: AutonomousApprovalMode,
+    summary: Option<&str>,
+) -> AutonomousMutationProposal {
+    let dedupe_key = dedupe_key.into();
+    let summary = summary
+        .and_then(|s| {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .unwrap_or_else(|| format!("autonomous mutation proposal approved for {dedupe_key}"));
+    AutonomousMutationProposal {
+        proposal_id: proposal_id.into(),
+        plan_id: plan_id.into(),
+        dedupe_key,
+        scope: Some(scope),
+        expected_evidence,
+        rollback_conditions,
+        approval_mode,
+        proposed: true,
+        reason_code: AutonomousProposalReasonCode::Proposed,
+        summary,
+        denial_condition: None,
+        fail_closed: false,
+    }
+}
+
+/// Construct a denied fail-closed `AutonomousMutationProposal`.
+pub fn deny_autonomous_mutation_proposal(
+    proposal_id: impl Into<String>,
+    plan_id: impl Into<String>,
+    dedupe_key: impl Into<String>,
+    reason_code: AutonomousProposalReasonCode,
+) -> AutonomousMutationProposal {
+    let (description, recovery_hint) = match reason_code {
+        AutonomousProposalReasonCode::DeniedPlanNotApproved => (
+            "source plan was not approved; cannot generate proposal",
+            "ensure the autonomous task plan is approved before proposing a mutation",
+        ),
+        AutonomousProposalReasonCode::DeniedNoTargetScope => (
+            "no bounded target scope could be determined for this task class",
+            "verify that the task class maps to a known set of target paths",
+        ),
+        AutonomousProposalReasonCode::DeniedWeakEvidence => (
+            "the expected evidence set is empty or insufficient",
+            "strengthen evidence requirements before reattempting proposal",
+        ),
+        AutonomousProposalReasonCode::DeniedOutOfBounds => (
+            "proposal would mutate files outside of bounded policy scope",
+            "restrict targets to explicitly allowed paths and retry",
+        ),
+        AutonomousProposalReasonCode::UnknownFailClosed => (
+            "proposal generation failed with an unmapped reason; fail closed",
+            "require explicit maintainer triage before retry",
+        ),
+        AutonomousProposalReasonCode::Proposed => (
+            "unexpected proposed reason on deny path",
+            "use approve_autonomous_mutation_proposal for proposed outcomes",
+        ),
+    };
+    let dedupe_key = dedupe_key.into();
+    let summary = format!("autonomous mutation proposal denied [{reason_code:?}]: {description}");
+    AutonomousMutationProposal {
+        proposal_id: proposal_id.into(),
+        plan_id: plan_id.into(),
+        dedupe_key,
+        scope: None,
+        expected_evidence: Vec::new(),
+        rollback_conditions: Vec::new(),
+        approval_mode: AutonomousApprovalMode::RequiresHumanReview,
+        proposed: false,
+        reason_code,
+        summary,
+        denial_condition: Some(AutonomousDenialCondition {
+            reason_code: AutonomousPlanReasonCode::UnknownFailClosed,
+            description: description.to_string(),
+            recovery_hint: recovery_hint.to_string(),
+        }),
+        fail_closed: true,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SelfEvolutionSelectionReasonCode {

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,7 +11,7 @@ description = "Self-evolving kernel orchestration for Oris."
 anyhow = "1.0"
 async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
-oris-agent-contract = { version = "0.5.0", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.1", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -10,18 +10,21 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
     accept_discovered_candidate, accept_self_evolution_selection_decision,
-    approve_autonomous_task_plan, deny_autonomous_task_plan, deny_discovered_candidate,
+    approve_autonomous_mutation_proposal, approve_autonomous_task_plan,
+    deny_autonomous_mutation_proposal, deny_autonomous_task_plan, deny_discovered_candidate,
     infer_mutation_needed_failure_reason_code, infer_replay_fallback_reason_code,
     normalize_mutation_needed_failure_contract, normalize_replay_fallback_contract,
-    reject_self_evolution_selection_decision, AgentRole, AutonomousCandidateSource,
-    AutonomousIntakeInput, AutonomousIntakeOutput, AutonomousIntakeReasonCode,
-    AutonomousPlanReasonCode, AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass,
-    CoordinationMessage, CoordinationPlan, CoordinationPrimitive, CoordinationResult,
-    CoordinationTask, DiscoveredCandidate, ExecutionFeedback, MutationNeededFailureContract,
-    MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal,
-    MutationProposalContractReasonCode, MutationProposalEvidence, MutationProposalScope,
-    MutationProposalValidationBudget, ReplayFallbackReasonCode, ReplayFeedback,
-    ReplayPlannerDirective, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
+    reject_self_evolution_selection_decision, AgentRole, AutonomousApprovalMode,
+    AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeOutput,
+    AutonomousIntakeReasonCode, AutonomousMutationProposal, AutonomousPlanReasonCode,
+    AutonomousProposalReasonCode, AutonomousProposalScope, AutonomousRiskTier, AutonomousTaskPlan,
+    BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
+    CoordinationResult, CoordinationTask, DiscoveredCandidate, ExecutionFeedback,
+    MutationNeededFailureContract, MutationNeededFailureReasonCode,
+    MutationProposal as AgentMutationProposal, MutationProposalContractReasonCode,
+    MutationProposalEvidence, MutationProposalScope, MutationProposalValidationBudget,
+    ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
+    SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
     SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
     SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
@@ -3510,6 +3513,20 @@ impl<S: KernelState> EvoKernel<S> {
         autonomous_plan_for_candidate(candidate)
     }
 
+    /// Autonomous mutation proposal generation from an approved `AutonomousTaskPlan`.
+    ///
+    /// Generates a bounded, machine-readable `AutonomousMutationProposal` from an
+    /// approved plan. Unapproved plans, missing scope, or weak evidence sets produce
+    /// a denied fail-closed proposal.
+    ///
+    /// This is the `EVO26-AUTO-03` entry point. It does **not** execute the mutation.
+    pub fn propose_autonomous_mutation(
+        &self,
+        plan: &AutonomousTaskPlan,
+    ) -> AutonomousMutationProposal {
+        autonomous_proposal_for_plan(plan)
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5421,6 +5438,116 @@ fn autonomous_planning_params_for_class(
                 "cargo audit".to_string(),
                 "cargo test regression".to_string(),
                 "cargo build all features".to_string(),
+            ],
+        ),
+    }
+}
+
+/// Produce an `AutonomousMutationProposal` from an approved `AutonomousTaskPlan`.
+/// Unapproved plans, unsupported classes, or empty evidence sets produce a
+/// denied fail-closed proposal.
+fn autonomous_proposal_for_plan(plan: &AutonomousTaskPlan) -> AutonomousMutationProposal {
+    let proposal_id = stable_hash_json(&("proposal-v1", &plan.plan_id))
+        .unwrap_or_else(|_| compute_artifact_hash(&plan.plan_id));
+
+    if !plan.approved {
+        return deny_autonomous_mutation_proposal(
+            proposal_id,
+            plan.plan_id.clone(),
+            plan.dedupe_key.clone(),
+            AutonomousProposalReasonCode::DeniedPlanNotApproved,
+        );
+    }
+
+    let Some(task_class) = plan.task_class.clone() else {
+        return deny_autonomous_mutation_proposal(
+            proposal_id,
+            plan.plan_id.clone(),
+            plan.dedupe_key.clone(),
+            AutonomousProposalReasonCode::DeniedNoTargetScope,
+        );
+    };
+
+    let (target_paths, scope_rationale, max_files, rollback_conditions) =
+        autonomous_proposal_scope_for_class(&task_class);
+
+    if plan.expected_evidence.is_empty() {
+        return deny_autonomous_mutation_proposal(
+            proposal_id,
+            plan.plan_id.clone(),
+            plan.dedupe_key.clone(),
+            AutonomousProposalReasonCode::DeniedWeakEvidence,
+        );
+    }
+
+    let scope = AutonomousProposalScope {
+        target_paths,
+        scope_rationale,
+        max_files,
+    };
+
+    // Low-risk bounded classes are auto-approved; others require human review.
+    let approval_mode = if plan.risk_tier == AutonomousRiskTier::Low {
+        AutonomousApprovalMode::AutoApproved
+    } else {
+        AutonomousApprovalMode::RequiresHumanReview
+    };
+
+    let summary = format!(
+        "autonomous mutation proposal for {task_class:?} ({:?} approval, {} evidence items)",
+        approval_mode,
+        plan.expected_evidence.len()
+    );
+
+    approve_autonomous_mutation_proposal(
+        proposal_id,
+        plan.plan_id.clone(),
+        plan.dedupe_key.clone(),
+        scope,
+        plan.expected_evidence.clone(),
+        rollback_conditions,
+        approval_mode,
+        Some(&summary),
+    )
+}
+
+/// Returns `(target_paths, scope_rationale, max_files, rollback_conditions)` for a task class.
+fn autonomous_proposal_scope_for_class(
+    task_class: &BoundedTaskClass,
+) -> (Vec<String>, String, u8, Vec<String>) {
+    match task_class {
+        BoundedTaskClass::LintFix => (
+            vec!["crates/**/*.rs".to_string()],
+            "lint and compile fixes are bounded to source files only".to_string(),
+            5,
+            vec![
+                "revert if cargo fmt --all -- --check fails".to_string(),
+                "revert if any test regresses".to_string(),
+            ],
+        ),
+        BoundedTaskClass::DocsSingleFile => (
+            vec!["docs/**/*.md".to_string(), "crates/**/*.rs".to_string()],
+            "doc fixes are bounded to a single documentation or source file".to_string(),
+            1,
+            vec!["revert if docs review diff shows unrelated changes".to_string()],
+        ),
+        BoundedTaskClass::DocsMultiFile => (
+            vec!["docs/**/*.md".to_string()],
+            "multi-file doc updates are bounded to the docs directory".to_string(),
+            5,
+            vec![
+                "revert if docs review diff shows non-doc changes".to_string(),
+                "revert if link validation fails".to_string(),
+            ],
+        ),
+        BoundedTaskClass::CargoDepUpgrade => (
+            vec!["Cargo.toml".to_string(), "Cargo.lock".to_string()],
+            "dependency upgrades are bounded to manifest and lock files only".to_string(),
+            2,
+            vec![
+                "revert if cargo audit reports new vulnerability".to_string(),
+                "revert if any test regresses after upgrade".to_string(),
+                "revert if cargo build all features fails".to_string(),
             ],
         ),
     }

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -10,16 +10,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{Duration, Utc};
 use oris_agent_contract::{
-    AgentTask, AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeReasonCode,
-    AutonomousPlanReasonCode, AutonomousRiskTier, BoundedTaskClass, HumanApproval,
-    MutationNeededFailureReasonCode, MutationProposal, MutationProposalContractReasonCode,
-    MutationProposalEvidence, ReplayFallbackNextAction, ReplayFallbackReasonCode,
-    ReplayPlannerDirective, SelfEvolutionAcceptanceGateInput,
-    SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionAuditConsistencyResult,
-    SelfEvolutionCandidateIntakeRequest, SelfEvolutionSelectionReasonCode,
-    SupervisedDeliveryApprovalState, SupervisedDeliveryReasonCode, SupervisedDeliveryStatus,
-    SupervisedDevloopOutcome, SupervisedDevloopRequest, SupervisedDevloopStatus,
-    SupervisedExecutionDecision, SupervisedExecutionReasonCode, SupervisedValidationOutcome,
+    AgentTask, AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
+    AutonomousIntakeReasonCode, AutonomousPlanReasonCode, AutonomousProposalReasonCode,
+    AutonomousRiskTier, BoundedTaskClass, HumanApproval, MutationNeededFailureReasonCode,
+    MutationProposal, MutationProposalContractReasonCode, MutationProposalEvidence,
+    ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayPlannerDirective,
+    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
+    SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
+    SelfEvolutionSelectionReasonCode, SupervisedDeliveryApprovalState,
+    SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
+    SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
+    SupervisedExecutionReasonCode, SupervisedValidationOutcome,
 };
 use oris_evokernel::{
     extract_deterministic_signals, prepare_mutation, CommandValidator, EvoAssetState,
@@ -3777,4 +3778,168 @@ fn autonomous_planning_reason_codes_are_stable() {
     );
     assert!(AutonomousRiskTier::Low < AutonomousRiskTier::Medium);
     assert!(AutonomousRiskTier::Medium < AutonomousRiskTier::High);
+}
+
+// ── AUTO-03: Autonomous mutation proposal contracts ───────────────────────────
+
+#[test]
+fn autonomous_proposal_approves_lint_fix_plan() {
+    let kernel = make_evo_kernel_for_autonomous_intake("autonomous_proposal_approves_lint_fix");
+    let intake = AutonomousIntakeInput {
+        source_id: "ci-prop-001".to_string(),
+        candidate_source: AutonomousCandidateSource::LintRegression,
+        raw_signals: vec!["error[E0308]: mismatched types".to_string()],
+    };
+    let candidate = &kernel.discover_autonomous_candidates(&intake).candidates[0];
+    let plan = kernel.plan_autonomous_candidate(candidate);
+    assert!(plan.approved, "precondition: plan must be approved");
+
+    let proposal = kernel.propose_autonomous_mutation(&plan);
+    assert!(
+        proposal.proposed,
+        "LintFix plan must produce an approved proposal"
+    );
+    assert_eq!(proposal.reason_code, AutonomousProposalReasonCode::Proposed);
+    assert!(proposal.scope.is_some(), "scope must be set");
+    let scope = proposal.scope.unwrap();
+    assert!(
+        !scope.target_paths.is_empty(),
+        "target_paths must not be empty"
+    );
+    assert!(scope.max_files >= 1, "max_files must be at least 1");
+    assert!(
+        !proposal.expected_evidence.is_empty(),
+        "expected_evidence must not be empty"
+    );
+    assert!(
+        !proposal.rollback_conditions.is_empty(),
+        "rollback_conditions must not be empty"
+    );
+    assert_eq!(proposal.approval_mode, AutonomousApprovalMode::AutoApproved);
+    assert!(
+        !proposal.fail_closed,
+        "approved proposal must not be fail_closed"
+    );
+    assert!(!proposal.proposal_id.is_empty());
+    assert_eq!(proposal.plan_id, plan.plan_id);
+    assert_eq!(proposal.dedupe_key, plan.dedupe_key);
+}
+
+#[test]
+fn autonomous_proposal_denies_unapproved_plan_fail_closed() {
+    use oris_agent_contract::{deny_autonomous_task_plan, AutonomousPlanReasonCode};
+
+    let kernel = make_evo_kernel_for_autonomous_intake("autonomous_proposal_denies_unapproved");
+    let denied_plan = deny_autonomous_task_plan(
+        "plan-id-denied".to_string(),
+        "dedupe-denied".to_string(),
+        AutonomousRiskTier::High,
+        AutonomousPlanReasonCode::DeniedHighRisk,
+    );
+    assert!(!denied_plan.approved, "precondition: plan must be denied");
+
+    let proposal = kernel.propose_autonomous_mutation(&denied_plan);
+    assert!(
+        !proposal.proposed,
+        "unapproved plan must yield denied proposal"
+    );
+    assert_eq!(
+        proposal.reason_code,
+        AutonomousProposalReasonCode::DeniedPlanNotApproved
+    );
+    assert!(proposal.fail_closed, "denied proposal must be fail_closed");
+    assert!(
+        proposal.scope.is_none(),
+        "denied proposal must have no scope"
+    );
+    assert!(
+        proposal.denial_condition.is_some(),
+        "denial_condition must be set"
+    );
+}
+
+#[test]
+fn autonomous_proposal_approves_docs_single_file_plan() {
+    use oris_agent_contract::{approve_autonomous_task_plan, AutonomousRiskTier};
+
+    let kernel = make_evo_kernel_for_autonomous_intake("autonomous_proposal_approves_docs");
+    let plan = approve_autonomous_task_plan(
+        "plan-docs-001".to_string(),
+        "dedupe-docs-001".to_string(),
+        BoundedTaskClass::DocsSingleFile,
+        AutonomousRiskTier::Low,
+        90u8,
+        1u8,
+        vec!["docs review diff".to_string()],
+        Some("docs single-file plan"),
+    );
+
+    let proposal = kernel.propose_autonomous_mutation(&plan);
+    assert!(proposal.proposed, "DocsSingleFile plan must be approved");
+    assert_eq!(proposal.reason_code, AutonomousProposalReasonCode::Proposed);
+    assert_eq!(proposal.approval_mode, AutonomousApprovalMode::AutoApproved);
+    let scope = proposal.scope.expect("scope must be set");
+    assert_eq!(scope.max_files, 1, "DocsSingleFile must allow max 1 file");
+}
+
+#[test]
+fn autonomous_proposal_medium_risk_requires_human_review() {
+    use oris_agent_contract::{approve_autonomous_task_plan, AutonomousRiskTier};
+
+    let kernel = make_evo_kernel_for_autonomous_intake("autonomous_proposal_medium_risk_review");
+    let plan = approve_autonomous_task_plan(
+        "plan-dep-001".to_string(),
+        "dedupe-dep-001".to_string(),
+        BoundedTaskClass::CargoDepUpgrade,
+        AutonomousRiskTier::Medium,
+        70u8,
+        3u8,
+        vec!["cargo audit".to_string(), "cargo test".to_string()],
+        None,
+    );
+
+    let proposal = kernel.propose_autonomous_mutation(&plan);
+    assert!(
+        proposal.proposed,
+        "CargoDepUpgrade plan must produce a proposal"
+    );
+    assert_eq!(
+        proposal.approval_mode,
+        AutonomousApprovalMode::RequiresHumanReview,
+        "medium-risk proposals must require human review"
+    );
+    let scope = proposal.scope.expect("scope must be set");
+    assert_eq!(scope.max_files, 2, "CargoDepUpgrade must allow max 2 files");
+}
+
+#[test]
+fn autonomous_proposal_reason_codes_are_stable() {
+    assert_eq!(
+        format!("{:?}", AutonomousProposalReasonCode::Proposed),
+        "Proposed"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousProposalReasonCode::DeniedPlanNotApproved),
+        "DeniedPlanNotApproved"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousProposalReasonCode::DeniedNoTargetScope),
+        "DeniedNoTargetScope"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousProposalReasonCode::DeniedWeakEvidence),
+        "DeniedWeakEvidence"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousProposalReasonCode::DeniedOutOfBounds),
+        "DeniedOutOfBounds"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousApprovalMode::AutoApproved),
+        "AutoApproved"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousApprovalMode::RequiresHumanReview),
+        "RequiresHumanReview"
+    );
 }

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.12.0", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.12.2", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -292,3 +292,41 @@ fn autonomous_task_planning_types_resolve() {
             < oris_runtime::agent_contract::AutonomousRiskTier::High
     );
 }
+
+/// Issue #266 — EVO26-AUTO-03: Autonomous mutation proposal types resolve via facade
+#[test]
+fn autonomous_mutation_proposal_types_resolve() {
+    assert_type::<oris_runtime::agent_contract::AutonomousApprovalMode>();
+    assert_type::<oris_runtime::agent_contract::AutonomousProposalReasonCode>();
+    assert_type::<oris_runtime::agent_contract::AutonomousProposalScope>();
+    assert_type::<oris_runtime::agent_contract::AutonomousMutationProposal>();
+
+    // Constructor helpers resolve
+    let scope = oris_runtime::agent_contract::AutonomousProposalScope {
+        target_paths: vec!["crates/**/*.rs".to_string()],
+        scope_rationale: "test scope".to_string(),
+        max_files: 3,
+    };
+    let _approved: oris_runtime::agent_contract::AutonomousMutationProposal =
+        oris_runtime::agent_contract::approve_autonomous_mutation_proposal(
+            "prop-id-1".to_string(),
+            "plan-id-1".to_string(),
+            "dedupe-key-1".to_string(),
+            scope,
+            vec!["cargo fmt".to_string()],
+            vec!["revert on failure".to_string()],
+            oris_runtime::agent_contract::AutonomousApprovalMode::AutoApproved,
+            Some("test proposal"),
+        );
+    let _denied: oris_runtime::agent_contract::AutonomousMutationProposal =
+        oris_runtime::agent_contract::deny_autonomous_mutation_proposal(
+            "prop-id-2".to_string(),
+            "plan-id-2".to_string(),
+            "dedupe-key-2".to_string(),
+            oris_runtime::agent_contract::AutonomousProposalReasonCode::DeniedPlanNotApproved,
+        );
+
+    // Variants accessible
+    let _mode = oris_runtime::agent_contract::AutonomousApprovalMode::AutoApproved;
+    let _code = oris_runtime::agent_contract::AutonomousProposalReasonCode::Proposed;
+}


### PR DESCRIPTION
Closes #266

## Summary
Add AUTO-03 autonomous mutation proposal contracts: typed approval-mode routing (AutoApproved/RequiresHumanReview) and AutonomousMutationProposal structs to oris-agent-contract; EvoKernel::propose_autonomous_mutation method in oris-evokernel.

## Validation
- `cargo fmt --all -- --check` passed
- `cargo test -p oris-evokernel --test evolution_lifecycle_regression` — 77 tests ok (10 new autonomous tests)
- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental autonomous_mutation_proposal` — 1 test ok
- `cargo build --all --release --all-features` passed
- `cargo test --release --all-features` — 0 failures
- Released as oris-agent-contract v0.5.1, oris-evokernel v0.12.2, oris-runtime v0.35.0
