### PR TITLE
feat(auto-04): semantic task-class generalization (#267)

### DIFF
--- a/RELEASE_v0.36.0.md
+++ b/RELEASE_v0.36.0.md
@@ -1,0 +1,43 @@
+# Release v0.36.0
+
+## oris-runtime v0.36.0
+
+### Summary
+
+Implements **AUTO-04: Semantic Task-Class Generalization Beyond Normalized Signals** (Issue #267).
+
+Adds a typed semantic equivalence layer that allows replay selection to generalize beyond exact normalized signal matching to broader task families. False-positive prevention is maintained: only explicitly approved families are replayed; unrelated tasks do not replay.
+
+### New Types (`oris-agent-contract`)
+
+- `TaskEquivalenceClass` — semantic family groupings: `DocumentationEdit`, `StaticAnalysisFix`, `DependencyManifestUpdate`, `Unclassified`
+- `EquivalenceExplanation` — structured audit record: `task_equivalence_class`, `rationale`, `matching_features`, `replay_match_confidence`
+- `SemanticReplayReasonCode` — `EquivalenceMatchApproved`, `LowConfidenceDenied`, `NoEquivalenceClassMatch`, `EquivalenceClassNotAllowed`, `UnknownFailClosed`
+- `SemanticReplayDecision` — `evaluation_id`, `task_id`, `replay_decision`, `equivalence_explanation`, `reason_code`, `summary`, `fail_closed`
+- `approve_semantic_replay()` — constructor for an approved decision
+- `deny_semantic_replay()` — constructor for a denied decision (fail_closed=true)
+
+### New Method (`oris-evokernel`)
+
+- `EvoKernel::evaluate_semantic_replay(task_id, task_class: &BoundedTaskClass) -> SemanticReplayDecision`
+  - Low-risk classes (`LintFix`, `DocsSingleFile`) → `EquivalenceMatchApproved`, `fail_closed=false`
+  - Medium-risk classes (`DocsMultiFile`, `CargoDepUpgrade`) → `EquivalenceClassNotAllowed`, `fail_closed=true`
+  - Returns full `EquivalenceExplanation` with matching_features and replay_match_confidence for approved decisions
+
+### Semantic Equivalence Policy
+
+| `BoundedTaskClass`  | `TaskEquivalenceClass`         | Auto-Replay | Confidence |
+|---------------------|-------------------------------|-------------|------------|
+| `LintFix`           | `StaticAnalysisFix`           | Yes         | 95         |
+| `DocsSingleFile`    | `DocumentationEdit`           | Yes         | 90         |
+| `DocsMultiFile`     | `DocumentationEdit`           | No (human review) | 75  |
+| `CargoDepUpgrade`   | `DependencyManifestUpdate`    | No (human review) | 72  |
+
+### Tests
+
+- 5 regression tests (`semantic_replay_*`) in `evolution_lifecycle_regression.rs`
+- 1 wiring gate test `semantic_replay_decision_types_resolve` in `evolution_feature_wiring.rs`
+
+### Closes
+
+- Issue #267 (AUTO-04)

--- a/crates/oris-agent-contract/Cargo.toml
+++ b/crates/oris-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-agent-contract"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -1115,6 +1115,125 @@ pub fn deny_autonomous_mutation_proposal(
     }
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// AUTO-04: Semantic Task-Class Generalization Beyond Normalized Signals
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Broader semantic equivalence families for replay generalization.
+///
+/// A `TaskEquivalenceClass` groups bounded task classes that share enough
+/// semantic properties to allow cross-task replay within the family while
+/// keeping false-positive replay rates at zero for unrelated work.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskEquivalenceClass {
+    /// Any documentation edit — single-file or multi-file docs changes are
+    /// in the same semantic family.
+    DocumentationEdit,
+    /// Pure static-analysis or compiler-driven code fixes (lints, clippy, fmt).
+    StaticAnalysisFix,
+    /// Dependency manifest updates (Cargo.toml, Cargo.lock upgrades).
+    DependencyManifestUpdate,
+    /// Catch-all: task does not belong to any recognized equivalence family.
+    Unclassified,
+}
+
+/// Human-readable and machine-auditable explanation for why two tasks are
+/// considered semantically equivalent for replay selection purposes.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EquivalenceExplanation {
+    /// The equivalence class that was matched.
+    pub task_equivalence_class: TaskEquivalenceClass,
+    /// Short human-readable rationale for the equivalence match.
+    pub rationale: String,
+    /// Specific features that were used to determine equivalence.
+    pub matching_features: Vec<String>,
+    /// Confidence score in [0, 100] that this is a true equivalence match.
+    pub replay_match_confidence: u8,
+}
+
+/// Reason code explaining the outcome of a semantic replay evaluation.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticReplayReasonCode {
+    /// Task matched a known equivalence class and replay is permitted.
+    EquivalenceMatchApproved,
+    /// Task is in an approved class but confidence is below the minimum threshold.
+    LowConfidenceDenied,
+    /// Task did not match any approved semantic equivalence class.
+    NoEquivalenceClassMatch,
+    /// Replay was not permitted because the equivalence class is not on the
+    /// allowed list for the current risk tier.
+    EquivalenceClassNotAllowed,
+    /// Semantic evaluation failed with an unexpected state; fail closed.
+    UnknownFailClosed,
+}
+
+/// Decision produced by semantic replay evaluation.
+///
+/// Consumers must check `replay_decision` and `fail_closed` before attempting
+/// any replay operation. When `fail_closed` is `true`, replay must not proceed
+/// regardless of `replay_decision`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SemanticReplayDecision {
+    /// Unique identifier for this evaluation.
+    pub evaluation_id: String,
+    /// The task identifier being evaluated.
+    pub task_id: String,
+    /// Whether semantic replay is permitted for this task.
+    pub replay_decision: bool,
+    /// The equivalence explanation that drove the decision, if any.
+    pub equivalence_explanation: Option<EquivalenceExplanation>,
+    /// The reason code for this decision.
+    pub reason_code: SemanticReplayReasonCode,
+    /// Human-readable decision summary.
+    pub summary: String,
+    /// Safety gate. When `true`, replay must be blocked regardless of
+    /// `replay_decision`.
+    pub fail_closed: bool,
+}
+
+/// Construct an approved `SemanticReplayDecision`.
+pub fn approve_semantic_replay(
+    evaluation_id: impl Into<String>,
+    task_id: impl Into<String>,
+    explanation: EquivalenceExplanation,
+) -> SemanticReplayDecision {
+    let summary = format!(
+        "semantic replay approved [equivalence_class={:?}, confidence={}]",
+        explanation.task_equivalence_class, explanation.replay_match_confidence
+    );
+    SemanticReplayDecision {
+        evaluation_id: evaluation_id.into(),
+        task_id: task_id.into(),
+        replay_decision: true,
+        reason_code: SemanticReplayReasonCode::EquivalenceMatchApproved,
+        equivalence_explanation: Some(explanation),
+        summary,
+        fail_closed: false,
+    }
+}
+
+/// Construct a denied `SemanticReplayDecision`.
+pub fn deny_semantic_replay(
+    evaluation_id: impl Into<String>,
+    task_id: impl Into<String>,
+    reason_code: SemanticReplayReasonCode,
+    context: impl Into<String>,
+) -> SemanticReplayDecision {
+    let context: String = context.into();
+    let summary = format!("semantic replay denied [{reason_code:?}]: {context}");
+    SemanticReplayDecision {
+        evaluation_id: evaluation_id.into(),
+        task_id: task_id.into(),
+        replay_decision: false,
+        equivalence_explanation: None,
+        reason_code,
+        summary,
+        fail_closed: true,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SelfEvolutionSelectionReasonCode {

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,7 +11,7 @@ description = "Self-evolving kernel orchestration for Oris."
 anyhow = "1.0"
 async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
-oris-agent-contract = { version = "0.5.1", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.2", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -10,29 +10,30 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
     accept_discovered_candidate, accept_self_evolution_selection_decision,
-    approve_autonomous_mutation_proposal, approve_autonomous_task_plan,
+    approve_autonomous_mutation_proposal, approve_autonomous_task_plan, approve_semantic_replay,
     deny_autonomous_mutation_proposal, deny_autonomous_task_plan, deny_discovered_candidate,
-    infer_mutation_needed_failure_reason_code, infer_replay_fallback_reason_code,
-    normalize_mutation_needed_failure_contract, normalize_replay_fallback_contract,
-    reject_self_evolution_selection_decision, AgentRole, AutonomousApprovalMode,
-    AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeOutput,
-    AutonomousIntakeReasonCode, AutonomousMutationProposal, AutonomousPlanReasonCode,
-    AutonomousProposalReasonCode, AutonomousProposalScope, AutonomousRiskTier, AutonomousTaskPlan,
-    BoundedTaskClass, CoordinationMessage, CoordinationPlan, CoordinationPrimitive,
-    CoordinationResult, CoordinationTask, DiscoveredCandidate, ExecutionFeedback,
-    MutationNeededFailureContract, MutationNeededFailureReasonCode,
-    MutationProposal as AgentMutationProposal, MutationProposalContractReasonCode,
-    MutationProposalEvidence, MutationProposalScope, MutationProposalValidationBudget,
-    ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
-    SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
+    deny_semantic_replay, infer_mutation_needed_failure_reason_code,
+    infer_replay_fallback_reason_code, normalize_mutation_needed_failure_contract,
+    normalize_replay_fallback_contract, reject_self_evolution_selection_decision, AgentRole,
+    AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
+    AutonomousIntakeOutput, AutonomousIntakeReasonCode, AutonomousMutationProposal,
+    AutonomousPlanReasonCode, AutonomousProposalReasonCode, AutonomousProposalScope,
+    AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass, CoordinationMessage,
+    CoordinationPlan, CoordinationPrimitive, CoordinationResult, CoordinationTask,
+    DiscoveredCandidate, EquivalenceExplanation, ExecutionFeedback, MutationNeededFailureContract,
+    MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal,
+    MutationProposalContractReasonCode, MutationProposalEvidence, MutationProposalScope,
+    MutationProposalValidationBudget, ReplayFallbackReasonCode, ReplayFeedback,
+    ReplayPlannerDirective, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
     SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
     SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
     SelfEvolutionReasonCodeMatrix, SelfEvolutionSelectionDecision,
-    SelfEvolutionSelectionReasonCode, SupervisedDeliveryApprovalState, SupervisedDeliveryContract,
-    SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
-    SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
-    SupervisedExecutionReasonCode, SupervisedValidationOutcome,
+    SelfEvolutionSelectionReasonCode, SemanticReplayDecision, SemanticReplayReasonCode,
+    SupervisedDeliveryApprovalState, SupervisedDeliveryContract, SupervisedDeliveryReasonCode,
+    SupervisedDeliveryStatus, SupervisedDevloopOutcome, SupervisedDevloopRequest,
+    SupervisedDevloopStatus, SupervisedExecutionDecision, SupervisedExecutionReasonCode,
+    SupervisedValidationOutcome, TaskEquivalenceClass,
 };
 use oris_economics::{EconomicsSignal, EvuLedger, StakePolicy};
 use oris_evolution::{
@@ -3527,6 +3528,22 @@ impl<S: KernelState> EvoKernel<S> {
         autonomous_proposal_for_plan(plan)
     }
 
+    /// Semantic task-class generalization evaluation for replay selection.
+    ///
+    /// Determines whether a task described by `task_id` and `task_class` can
+    /// participate in broad-family replay beyond exact signal matching.
+    /// Returns a `SemanticReplayDecision` with an audit-ready
+    /// `EquivalenceExplanation` when replay is approved.
+    ///
+    /// This is the `EVO26-AUTO-04` entry point. It does **not** execute replay.
+    pub fn evaluate_semantic_replay(
+        &self,
+        task_id: impl Into<String>,
+        task_class: &BoundedTaskClass,
+    ) -> SemanticReplayDecision {
+        semantic_replay_for_class(task_id, task_class)
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5550,6 +5567,85 @@ fn autonomous_proposal_scope_for_class(
                 "revert if cargo build all features fails".to_string(),
             ],
         ),
+    }
+}
+
+/// Semantic replay evaluation for a given `BoundedTaskClass`.
+///
+/// Maps each bounded class to its semantic equivalence family and returns
+/// an approved or denied `SemanticReplayDecision` with a full
+/// `EquivalenceExplanation` for audit.  Only `Low`-risk classes are
+/// auto-approved; `Medium`/`High`-risk classes require human review (denied).
+fn semantic_replay_for_class(
+    task_id: impl Into<String>,
+    task_class: &BoundedTaskClass,
+) -> SemanticReplayDecision {
+    let task_id: String = task_id.into();
+    let evaluation_id = next_id("srd");
+
+    let (equiv_class, rationale, confidence, features, approved) = match task_class {
+        BoundedTaskClass::LintFix => (
+            TaskEquivalenceClass::StaticAnalysisFix,
+            "lint and compile fixes share static-analysis signal family".to_string(),
+            95u8,
+            vec![
+                "compiler-diagnostic signal present".to_string(),
+                "no logic change — style or lint only".to_string(),
+                "bounded to source files".to_string(),
+            ],
+            true,
+        ),
+        BoundedTaskClass::DocsSingleFile => (
+            TaskEquivalenceClass::DocumentationEdit,
+            "single-file doc edits belong to the documentation edit equivalence family".to_string(),
+            90u8,
+            vec![
+                "change confined to one documentation or source file".to_string(),
+                "no runtime behaviour change".to_string(),
+            ],
+            true,
+        ),
+        BoundedTaskClass::DocsMultiFile => (
+            TaskEquivalenceClass::DocumentationEdit,
+            "multi-file doc edits belong to the documentation edit equivalence family; medium risk requires human review".to_string(),
+            75u8,
+            vec![
+                "change spans multiple documentation files".to_string(),
+                "medium risk tier — human review required".to_string(),
+            ],
+            false,
+        ),
+        BoundedTaskClass::CargoDepUpgrade => (
+            TaskEquivalenceClass::DependencyManifestUpdate,
+            "dependency upgrades belong to manifest-update equivalence family; medium risk requires human review".to_string(),
+            72u8,
+            vec![
+                "manifest-only change (Cargo.toml / Cargo.lock)".to_string(),
+                "medium risk tier — human review required".to_string(),
+            ],
+            false,
+        ),
+    };
+
+    let explanation = EquivalenceExplanation {
+        task_equivalence_class: equiv_class,
+        rationale,
+        matching_features: features,
+        replay_match_confidence: confidence,
+    };
+
+    if approved {
+        approve_semantic_replay(evaluation_id, task_id, explanation)
+    } else {
+        deny_semantic_replay(
+            evaluation_id,
+            task_id,
+            SemanticReplayReasonCode::EquivalenceClassNotAllowed,
+            format!(
+                "equivalence class {:?} is not auto-approved for semantic replay",
+                explanation.task_equivalence_class
+            ),
+        )
     }
 }
 

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -17,10 +17,10 @@ use oris_agent_contract::{
     ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayPlannerDirective,
     SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
-    SelfEvolutionSelectionReasonCode, SupervisedDeliveryApprovalState,
+    SelfEvolutionSelectionReasonCode, SemanticReplayReasonCode, SupervisedDeliveryApprovalState,
     SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
     SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
-    SupervisedExecutionReasonCode, SupervisedValidationOutcome,
+    SupervisedExecutionReasonCode, SupervisedValidationOutcome, TaskEquivalenceClass,
 };
 use oris_evokernel::{
     extract_deterministic_signals, prepare_mutation, CommandValidator, EvoAssetState,
@@ -3941,5 +3941,135 @@ fn autonomous_proposal_reason_codes_are_stable() {
     assert_eq!(
         format!("{:?}", AutonomousApprovalMode::RequiresHumanReview),
         "RequiresHumanReview"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AUTO-04 regression tests: semantic task-class generalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn semantic_replay_lint_fix_is_approved_with_static_analysis_class() {
+    let kernel = make_evo_kernel_for_autonomous_intake("semantic_replay_lint_fix");
+    let decision = kernel.evaluate_semantic_replay("task-lint-001", &BoundedTaskClass::LintFix);
+    assert!(decision.replay_decision, "LintFix should be auto-approved");
+    assert!(
+        !decision.fail_closed,
+        "approved decision must not be fail-closed"
+    );
+    let expl = decision
+        .equivalence_explanation
+        .expect("explanation must be present for approved decision");
+    assert_eq!(
+        expl.task_equivalence_class,
+        TaskEquivalenceClass::StaticAnalysisFix
+    );
+    assert!(
+        expl.replay_match_confidence >= 90,
+        "LintFix confidence should be >= 90"
+    );
+    assert_eq!(
+        decision.reason_code,
+        SemanticReplayReasonCode::EquivalenceMatchApproved
+    );
+}
+
+#[test]
+fn semantic_replay_docs_single_file_is_approved_with_documentation_edit_class() {
+    let kernel = make_evo_kernel_for_autonomous_intake("semantic_replay_docs_single");
+    let decision =
+        kernel.evaluate_semantic_replay("task-docs-001", &BoundedTaskClass::DocsSingleFile);
+    assert!(
+        decision.replay_decision,
+        "DocsSingleFile should be auto-approved"
+    );
+    assert!(!decision.fail_closed);
+    let expl = decision
+        .equivalence_explanation
+        .expect("explanation must be present");
+    assert_eq!(
+        expl.task_equivalence_class,
+        TaskEquivalenceClass::DocumentationEdit
+    );
+    assert_eq!(
+        decision.reason_code,
+        SemanticReplayReasonCode::EquivalenceMatchApproved
+    );
+}
+
+#[test]
+fn semantic_replay_docs_multi_file_is_denied_requires_human_review() {
+    let kernel = make_evo_kernel_for_autonomous_intake("semantic_replay_docs_multi");
+    let decision =
+        kernel.evaluate_semantic_replay("task-docs-multi-001", &BoundedTaskClass::DocsMultiFile);
+    assert!(
+        !decision.replay_decision,
+        "DocsMultiFile medium-risk should be denied"
+    );
+    assert!(decision.fail_closed, "denied decision must be fail-closed");
+    assert!(
+        decision.equivalence_explanation.is_none(),
+        "denied decision has no equivalence explanation"
+    );
+    assert_eq!(
+        decision.reason_code,
+        SemanticReplayReasonCode::EquivalenceClassNotAllowed
+    );
+}
+
+#[test]
+fn semantic_replay_cargo_dep_upgrade_is_denied_requires_human_review() {
+    let kernel = make_evo_kernel_for_autonomous_intake("semantic_replay_cargo_dep");
+    let decision =
+        kernel.evaluate_semantic_replay("task-dep-001", &BoundedTaskClass::CargoDepUpgrade);
+    assert!(
+        !decision.replay_decision,
+        "CargoDepUpgrade medium-risk should be denied"
+    );
+    assert!(decision.fail_closed);
+    assert_eq!(
+        decision.reason_code,
+        SemanticReplayReasonCode::EquivalenceClassNotAllowed
+    );
+}
+
+#[test]
+fn semantic_replay_reason_codes_and_equivalence_classes_are_stable() {
+    // discriminant stability regression — names must not silently change
+    assert_eq!(
+        format!("{:?}", SemanticReplayReasonCode::EquivalenceMatchApproved),
+        "EquivalenceMatchApproved"
+    );
+    assert_eq!(
+        format!("{:?}", SemanticReplayReasonCode::LowConfidenceDenied),
+        "LowConfidenceDenied"
+    );
+    assert_eq!(
+        format!("{:?}", SemanticReplayReasonCode::NoEquivalenceClassMatch),
+        "NoEquivalenceClassMatch"
+    );
+    assert_eq!(
+        format!("{:?}", SemanticReplayReasonCode::EquivalenceClassNotAllowed),
+        "EquivalenceClassNotAllowed"
+    );
+    assert_eq!(
+        format!("{:?}", SemanticReplayReasonCode::UnknownFailClosed),
+        "UnknownFailClosed"
+    );
+    assert_eq!(
+        format!("{:?}", TaskEquivalenceClass::DocumentationEdit),
+        "DocumentationEdit"
+    );
+    assert_eq!(
+        format!("{:?}", TaskEquivalenceClass::StaticAnalysisFix),
+        "StaticAnalysisFix"
+    );
+    assert_eq!(
+        format!("{:?}", TaskEquivalenceClass::DependencyManifestUpdate),
+        "DependencyManifestUpdate"
+    );
+    assert_eq!(
+        format!("{:?}", TaskEquivalenceClass::Unclassified),
+        "Unclassified"
     );
 }

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.12.2", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.12.3", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -330,3 +330,35 @@ fn autonomous_mutation_proposal_types_resolve() {
     let _mode = oris_runtime::agent_contract::AutonomousApprovalMode::AutoApproved;
     let _code = oris_runtime::agent_contract::AutonomousProposalReasonCode::Proposed;
 }
+
+#[test]
+fn semantic_replay_decision_types_resolve() {
+    // AUTO-04 wiring gate: ensure TaskEquivalenceClass, EquivalenceExplanation,
+    // SemanticReplayDecision, SemanticReplayReasonCode, approve_semantic_replay,
+    // deny_semantic_replay are reachable via oris_runtime::agent_contract.
+
+    let explanation = oris_runtime::agent_contract::EquivalenceExplanation {
+        task_equivalence_class:
+            oris_runtime::agent_contract::TaskEquivalenceClass::StaticAnalysisFix,
+        rationale: "lint task semantic equivalence".to_string(),
+        matching_features: vec!["compiler-diagnostic signal".to_string()],
+        replay_match_confidence: 95,
+    };
+    let _approved: oris_runtime::agent_contract::SemanticReplayDecision =
+        oris_runtime::agent_contract::approve_semantic_replay(
+            "eval-id-1".to_string(),
+            "task-id-1".to_string(),
+            explanation,
+        );
+    let _denied: oris_runtime::agent_contract::SemanticReplayDecision =
+        oris_runtime::agent_contract::deny_semantic_replay(
+            "eval-id-2".to_string(),
+            "task-id-2".to_string(),
+            oris_runtime::agent_contract::SemanticReplayReasonCode::NoEquivalenceClassMatch,
+            "no matching class",
+        );
+
+    // Variants accessible
+    let _class = oris_runtime::agent_contract::TaskEquivalenceClass::Unclassified;
+    let _code = oris_runtime::agent_contract::SemanticReplayReasonCode::UnknownFailClosed;
+}


### PR DESCRIPTION
Closes #267

## Summary
Add AUTO-04 semantic task-class generalization: typed equivalence families (StaticAnalysisFix, DocumentationEdit, DependencyManifestUpdate) with audit-ready EquivalenceExplanation and SemanticReplayDecision contracts. EvoKernel::evaluate_semantic_replay provides deterministic approval routing: Low-risk classes auto-approved, Medium-risk require human review.

## Validation
- `cargo fmt --all -- --check` passed
- `cargo test -p oris-evokernel --test evolution_lifecycle_regression semantic_replay_` — 5 tests ok
- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental semantic_replay_decision` — 1 test ok
- `cargo test --release --all-features` — 0 failures
- Released as oris-agent-contract v0.5.2, oris-evokernel v0.12.3, oris-runtime v0.36.0
