### PR TITLE
feat(auto-05): continuous confidence revalidation (#269)

### DIFF
--- a/RELEASE_v0.37.0.md
+++ b/RELEASE_v0.37.0.md
@@ -1,0 +1,64 @@
+# Release: oris-runtime v0.37.0
+
+## Summary
+
+Implements **AUTO-05 — Continuous Confidence Revalidation** for the autonomous
+evolution pipeline.
+
+Assets (genes and capsules) can now be continuously re-evaluated for replay
+eligibility as runtime confidence signals accumulate. Failed revalidation
+suspends replay automatically; assets with too many failures are demoted or
+quarantined.
+
+## New Types (`oris-agent-contract v0.5.3`)
+
+| Type | Kind | Description |
+|------|------|-------------|
+| `ConfidenceState` | `enum` | Asset lifecycle states: `Active`, `Decaying`, `Revalidating`, `Demoted`, `Quarantined` |
+| `RevalidationOutcome` | `enum` | Round outcome: `Passed`, `Failed`, `Pending`, `ErrorFailClosed` |
+| `ConfidenceDemotionReasonCode` | `enum` | Reason codes for demotion: `ConfidenceDecayThreshold`, `RepeatedReplayFailure`, `MaxFailureCountExceeded`, `ExplicitRevocation`, `UnknownFailClosed` |
+| `ReplayEligibility` | `enum` | `Eligible` / `Ineligible` after evaluation |
+| `ConfidenceRevalidationResult` | `struct` | Full result of one revalidation run |
+| `DemotionDecision` | `struct` | Asset demotion / quarantine transition record |
+
+## New Constructors (`oris-agent-contract v0.5.3`)
+
+| Constructor | Description |
+|-------------|-------------|
+| `pass_confidence_revalidation(…)` | Creates a passing result, restores `Active` state |
+| `fail_confidence_revalidation(…)` | Creates a failing result, marks asset `Ineligible`, `fail_closed=true` |
+| `demote_asset(…)` | Creates demotion decision; escalates to `Quarantined` when appropriate |
+
+## New Kernel Methods (`oris-evokernel v0.12.4`)
+
+| Method | Description |
+|--------|-------------|
+| `EvoKernel::evaluate_confidence_revalidation(asset_id, state, failures)` | Run a revalidation cycle; fail-closed at 3+ failures |
+| `EvoKernel::evaluate_asset_demotion(asset_id, prior_state, failures, reason)` | Produce demotion decision; quarantine at 5+ failures |
+
+## Policy
+
+- **Pass threshold**: `failure_count < 3` → `Passed`, `Eligible`, `fail_closed=false`
+- **Fail threshold**: `failure_count >= 3` → `Failed`, `Ineligible`, `fail_closed=true`
+- **Demote vs Quarantine**: `failure_count < 5` → `Demoted`; `failure_count >= 5` → `Quarantined`
+
+## Validation
+
+- `cargo fmt --all -- --check` ✓
+- 5 regression tests (`confidence_revalidation_*`) — all pass
+- 1 wiring gate test (`confidence_revalidation_decision_types_resolve`) — pass
+- `cargo build --all --release --all-features` ✓
+- `cargo test --release --all-features` ✓
+- `cargo publish -p oris-runtime --all-features --dry-run` ✓
+
+## Changed Crates
+
+| Crate | Old | New |
+|-------|-----|-----|
+| `oris-agent-contract` | 0.5.2 | 0.5.3 |
+| `oris-evokernel` | 0.12.3 | 0.12.4 |
+| `oris-runtime` | 0.36.0 | 0.37.0 |
+
+## Linked Issue
+
+Closes #269

--- a/crates/oris-agent-contract/Cargo.toml
+++ b/crates/oris-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-agent-contract"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -1234,6 +1234,180 @@ pub fn deny_semantic_replay(
     }
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// AUTO-05: Continuous Confidence Revalidation and Asset Demotion
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Current confidence lifecycle state of a reusable asset.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfidenceState {
+    /// Asset is healthy and eligible for replay.
+    Active,
+    /// Asset confidence has decayed below the warning threshold; still eligible
+    /// but flagged for revalidation.
+    Decaying,
+    /// Asset is undergoing shadow-mode replay revalidation; normal reuse
+    /// continues but evidence is accumulated.
+    Revalidating,
+    /// Asset has been demoted after failed reuse; replay is suspended pending
+    /// explicit re-promotion.
+    Demoted,
+    /// Asset is quarantined after repeated failures; replay is blocked until
+    /// explicit triage clears it.
+    Quarantined,
+}
+
+/// Outcome of a single confidence revalidation round.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RevalidationOutcome {
+    /// Revalidation completed and confidence was restored above threshold.
+    Passed,
+    /// Revalidation completed but confidence remains below threshold.
+    Failed,
+    /// Revalidation is still running (shadow phase not yet complete).
+    Pending,
+    /// Revalidation encountered an error; treat as failed for safety.
+    ErrorFailClosed,
+}
+
+/// Reason code for a demotion or quarantine transition.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfidenceDemotionReasonCode {
+    /// Asset was demoted because confidence decayed below the demotion threshold.
+    ConfidenceDecayThreshold,
+    /// Asset was demoted due to repeated failed reuse (replay failures).
+    RepeatedReplayFailure,
+    /// Asset was quarantined after surpassing the maximum failure count.
+    MaxFailureCountExceeded,
+    /// Asset was revoked by explicit maintainer action.
+    ExplicitRevocation,
+    /// Demotion failed with an unmapped state; fail closed.
+    UnknownFailClosed,
+}
+
+/// Whether an asset is currently eligible for replay selection.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayEligibility {
+    /// Asset is eligible; replay may proceed.
+    Eligible,
+    /// Asset is not eligible; replay must not proceed.
+    Ineligible,
+}
+
+/// Full revalidation decision produced after a confidence evaluation round.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfidenceRevalidationResult {
+    /// Unique identifier for this revalidation run.
+    pub revalidation_id: String,
+    /// The asset being revalidated (gene id or capsule id).
+    pub asset_id: String,
+    /// Current confidence state before this revalidation.
+    pub confidence_state: ConfidenceState,
+    /// Outcome of this revalidation round.
+    pub revalidation_result: RevalidationOutcome,
+    /// Whether replay is eligible after this evaluation.
+    pub replay_eligibility: ReplayEligibility,
+    /// Human-readable summary of the revalidation outcome.
+    pub summary: String,
+    /// Safety gate. When `true`, replay must not proceed regardless of
+    /// `replay_eligibility`.
+    pub fail_closed: bool,
+}
+
+/// Demotion or quarantine transition event.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemotionDecision {
+    /// Unique identifier for this demotion event.
+    pub demotion_id: String,
+    /// The asset being demoted or quarantined.
+    pub asset_id: String,
+    /// Prior state before this transition.
+    pub prior_state: ConfidenceState,
+    /// New state after this transition.
+    pub new_state: ConfidenceState,
+    /// Reason for the demotion.
+    pub reason_code: ConfidenceDemotionReasonCode,
+    /// Replay eligibility after this transition.
+    pub replay_eligibility: ReplayEligibility,
+    /// Human-readable summary.
+    pub summary: String,
+    /// Whether this demotion resulted in a quarantine transition.
+    pub quarantine_transition: bool,
+    /// Safety gate. Always `true` for any demotion event.
+    pub fail_closed: bool,
+}
+
+/// Construct a passing `ConfidenceRevalidationResult`.
+pub fn pass_confidence_revalidation(
+    revalidation_id: impl Into<String>,
+    asset_id: impl Into<String>,
+    prior_state: ConfidenceState,
+) -> ConfidenceRevalidationResult {
+    let asset_id: String = asset_id.into();
+    let summary =
+        format!("confidence revalidation passed for asset {asset_id}: restoring to Active");
+    ConfidenceRevalidationResult {
+        revalidation_id: revalidation_id.into(),
+        asset_id,
+        confidence_state: ConfidenceState::Active,
+        revalidation_result: RevalidationOutcome::Passed,
+        replay_eligibility: ReplayEligibility::Eligible,
+        summary,
+        fail_closed: false,
+    }
+}
+
+/// Construct a failing `ConfidenceRevalidationResult`.
+pub fn fail_confidence_revalidation(
+    revalidation_id: impl Into<String>,
+    asset_id: impl Into<String>,
+    prior_state: ConfidenceState,
+    outcome: RevalidationOutcome,
+) -> ConfidenceRevalidationResult {
+    let asset_id: String = asset_id.into();
+    let summary = format!(
+        "confidence revalidation failed for asset {asset_id} [{outcome:?}]: replay suspended"
+    );
+    ConfidenceRevalidationResult {
+        revalidation_id: revalidation_id.into(),
+        asset_id,
+        confidence_state: prior_state,
+        revalidation_result: outcome,
+        replay_eligibility: ReplayEligibility::Ineligible,
+        summary,
+        fail_closed: true,
+    }
+}
+
+/// Construct a `DemotionDecision`.
+pub fn demote_asset(
+    demotion_id: impl Into<String>,
+    asset_id: impl Into<String>,
+    prior_state: ConfidenceState,
+    new_state: ConfidenceState,
+    reason_code: ConfidenceDemotionReasonCode,
+) -> DemotionDecision {
+    let asset_id: String = asset_id.into();
+    let quarantine_transition = new_state == ConfidenceState::Quarantined;
+    let summary =
+        format!("asset {asset_id} demoted from {prior_state:?} to {new_state:?} [{reason_code:?}]");
+    DemotionDecision {
+        demotion_id: demotion_id.into(),
+        asset_id,
+        prior_state,
+        new_state,
+        reason_code,
+        replay_eligibility: ReplayEligibility::Ineligible,
+        summary,
+        quarantine_transition,
+        fail_closed: true,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SelfEvolutionSelectionReasonCode {

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,7 +11,7 @@ description = "Self-evolving kernel orchestration for Oris."
 anyhow = "1.0"
 async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
-oris-agent-contract = { version = "0.5.2", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.3", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -11,29 +11,31 @@ use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
     accept_discovered_candidate, accept_self_evolution_selection_decision,
     approve_autonomous_mutation_proposal, approve_autonomous_task_plan, approve_semantic_replay,
-    deny_autonomous_mutation_proposal, deny_autonomous_task_plan, deny_discovered_candidate,
-    deny_semantic_replay, infer_mutation_needed_failure_reason_code,
-    infer_replay_fallback_reason_code, normalize_mutation_needed_failure_contract,
-    normalize_replay_fallback_contract, reject_self_evolution_selection_decision, AgentRole,
+    demote_asset, deny_autonomous_mutation_proposal, deny_autonomous_task_plan,
+    deny_discovered_candidate, deny_semantic_replay, fail_confidence_revalidation,
+    infer_mutation_needed_failure_reason_code, infer_replay_fallback_reason_code,
+    normalize_mutation_needed_failure_contract, normalize_replay_fallback_contract,
+    pass_confidence_revalidation, reject_self_evolution_selection_decision, AgentRole,
     AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
     AutonomousIntakeOutput, AutonomousIntakeReasonCode, AutonomousMutationProposal,
     AutonomousPlanReasonCode, AutonomousProposalReasonCode, AutonomousProposalScope,
-    AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass, CoordinationMessage,
-    CoordinationPlan, CoordinationPrimitive, CoordinationResult, CoordinationTask,
+    AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass, ConfidenceDemotionReasonCode,
+    ConfidenceRevalidationResult, ConfidenceState, CoordinationMessage, CoordinationPlan,
+    CoordinationPrimitive, CoordinationResult, CoordinationTask, DemotionDecision,
     DiscoveredCandidate, EquivalenceExplanation, ExecutionFeedback, MutationNeededFailureContract,
     MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal,
     MutationProposalContractReasonCode, MutationProposalEvidence, MutationProposalScope,
     MutationProposalValidationBudget, ReplayFallbackReasonCode, ReplayFeedback,
-    ReplayPlannerDirective, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
-    SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
-    SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
-    SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
-    SelfEvolutionReasonCodeMatrix, SelfEvolutionSelectionDecision,
-    SelfEvolutionSelectionReasonCode, SemanticReplayDecision, SemanticReplayReasonCode,
-    SupervisedDeliveryApprovalState, SupervisedDeliveryContract, SupervisedDeliveryReasonCode,
-    SupervisedDeliveryStatus, SupervisedDevloopOutcome, SupervisedDevloopRequest,
-    SupervisedDevloopStatus, SupervisedExecutionDecision, SupervisedExecutionReasonCode,
-    SupervisedValidationOutcome, TaskEquivalenceClass,
+    ReplayPlannerDirective, RevalidationOutcome, SelfEvolutionAcceptanceGateContract,
+    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
+    SelfEvolutionApprovalEvidence, SelfEvolutionAuditConsistencyResult,
+    SelfEvolutionCandidateIntakeRequest, SelfEvolutionDeliveryOutcome,
+    SelfEvolutionMutationProposalContract, SelfEvolutionReasonCodeMatrix,
+    SelfEvolutionSelectionDecision, SelfEvolutionSelectionReasonCode, SemanticReplayDecision,
+    SemanticReplayReasonCode, SupervisedDeliveryApprovalState, SupervisedDeliveryContract,
+    SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
+    SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
+    SupervisedExecutionReasonCode, SupervisedValidationOutcome, TaskEquivalenceClass,
 };
 use oris_economics::{EconomicsSignal, EvuLedger, StakePolicy};
 use oris_evolution::{
@@ -3544,6 +3546,39 @@ impl<S: KernelState> EvoKernel<S> {
         semantic_replay_for_class(task_id, task_class)
     }
 
+    /// Continuous confidence revalidation evaluation for a given asset.
+    ///
+    /// Given the asset's `current_state` and its recent `failure_count`,
+    /// produces a `ConfidenceRevalidationResult` determining whether the asset
+    /// remains replay-eligible. Assets with three or more failures are
+    /// revalidated as failed; otherwise they pass.
+    ///
+    /// This is the `EVO26-AUTO-05` confidence revalidation entry point.
+    pub fn evaluate_confidence_revalidation(
+        &self,
+        asset_id: impl Into<String>,
+        current_state: ConfidenceState,
+        failure_count: u32,
+    ) -> ConfidenceRevalidationResult {
+        confidence_revalidation_for_asset(asset_id, current_state, failure_count)
+    }
+
+    /// Asset demotion decision for an asset that has exceeded failure policy.
+    ///
+    /// Promotes the decision from `Demoted` to `Quarantined` when
+    /// `failure_count >= 5`; `Demoted` otherwise.
+    ///
+    /// This is the `EVO26-AUTO-05` asset demotion entry point.
+    pub fn evaluate_asset_demotion(
+        &self,
+        asset_id: impl Into<String>,
+        prior_state: ConfidenceState,
+        failure_count: u32,
+        reason_code: ConfidenceDemotionReasonCode,
+    ) -> DemotionDecision {
+        asset_demotion_decision(asset_id, prior_state, failure_count, reason_code)
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5647,6 +5682,48 @@ fn semantic_replay_for_class(
             ),
         )
     }
+}
+
+/// Confidence revalidation logic for a single asset.
+///
+/// If `failure_count >= 3`, revalidation fails and replay is suspended.
+/// Otherwise the asset passes revalidation and confidence is restored.
+fn confidence_revalidation_for_asset(
+    asset_id: impl Into<String>,
+    current_state: ConfidenceState,
+    failure_count: u32,
+) -> ConfidenceRevalidationResult {
+    let asset_id: String = asset_id.into();
+    let revalidation_id = next_id("crv");
+
+    if failure_count >= 3 {
+        fail_confidence_revalidation(
+            revalidation_id,
+            asset_id,
+            current_state,
+            RevalidationOutcome::Failed,
+        )
+    } else {
+        pass_confidence_revalidation(revalidation_id, asset_id, current_state)
+    }
+}
+
+/// Asset demotion/quarantine decision.
+///
+/// Quarantines the asset when `failure_count >= 5`; demotes otherwise.
+fn asset_demotion_decision(
+    asset_id: impl Into<String>,
+    prior_state: ConfidenceState,
+    failure_count: u32,
+    reason_code: ConfidenceDemotionReasonCode,
+) -> DemotionDecision {
+    let demotion_id = next_id("dem");
+    let new_state = if failure_count >= 5 {
+        ConfidenceState::Quarantined
+    } else {
+        ConfidenceState::Demoted
+    };
+    demote_asset(demotion_id, asset_id, prior_state, new_state, reason_code)
 }
 
 fn find_declared_mutation(

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -12,10 +12,11 @@ use chrono::{Duration, Utc};
 use oris_agent_contract::{
     AgentTask, AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
     AutonomousIntakeReasonCode, AutonomousPlanReasonCode, AutonomousProposalReasonCode,
-    AutonomousRiskTier, BoundedTaskClass, HumanApproval, MutationNeededFailureReasonCode,
-    MutationProposal, MutationProposalContractReasonCode, MutationProposalEvidence,
+    AutonomousRiskTier, BoundedTaskClass, ConfidenceDemotionReasonCode, ConfidenceState,
+    HumanApproval, MutationNeededFailureReasonCode, MutationProposal,
+    MutationProposalContractReasonCode, MutationProposalEvidence, ReplayEligibility,
     ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayPlannerDirective,
-    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
+    RevalidationOutcome, SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
     SelfEvolutionSelectionReasonCode, SemanticReplayReasonCode, SupervisedDeliveryApprovalState,
     SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
@@ -4072,4 +4073,133 @@ fn semantic_replay_reason_codes_and_equivalence_classes_are_stable() {
         format!("{:?}", TaskEquivalenceClass::Unclassified),
         "Unclassified"
     );
+}
+
+// ─── AUTO-05: Continuous Confidence Revalidation ────────────────────────────
+
+#[test]
+fn confidence_revalidation_passes_for_active_asset_with_no_failures() {
+    let kernel = make_evo_kernel_for_autonomous_intake("crv_active_no_failures");
+    let result = kernel.evaluate_confidence_revalidation("asset-001", ConfidenceState::Active, 0);
+    assert_eq!(
+        result.replay_eligibility,
+        ReplayEligibility::Eligible,
+        "active asset with 0 failures should pass"
+    );
+    assert!(
+        !result.fail_closed,
+        "passing result must not be fail-closed"
+    );
+    assert_eq!(result.revalidation_result, RevalidationOutcome::Passed);
+}
+
+#[test]
+fn confidence_revalidation_passes_for_decaying_asset_below_threshold() {
+    let kernel = make_evo_kernel_for_autonomous_intake("crv_decaying_below");
+    let result = kernel.evaluate_confidence_revalidation("asset-002", ConfidenceState::Decaying, 2);
+    assert_eq!(
+        result.replay_eligibility,
+        ReplayEligibility::Eligible,
+        "2 failures is below threshold — should pass"
+    );
+    assert!(!result.fail_closed);
+    assert_eq!(result.revalidation_result, RevalidationOutcome::Passed);
+}
+
+#[test]
+fn confidence_revalidation_fails_for_asset_with_three_or_more_failures() {
+    let kernel = make_evo_kernel_for_autonomous_intake("crv_three_failures");
+    let result =
+        kernel.evaluate_confidence_revalidation("asset-003", ConfidenceState::Revalidating, 3);
+    assert_eq!(
+        result.replay_eligibility,
+        ReplayEligibility::Ineligible,
+        "3 failures should fail revalidation"
+    );
+    assert!(
+        result.fail_closed,
+        "failed revalidation must be fail-closed"
+    );
+    assert_eq!(result.revalidation_result, RevalidationOutcome::Failed);
+}
+
+#[test]
+fn confidence_revalidation_demotion_escalates_to_quarantine_at_five_failures() {
+    let kernel = make_evo_kernel_for_autonomous_intake("crv_quarantine");
+    // 4 failures → Demoted
+    let d4 = kernel.evaluate_asset_demotion(
+        "asset-004",
+        ConfidenceState::Decaying,
+        4,
+        ConfidenceDemotionReasonCode::ConfidenceDecayThreshold,
+    );
+    assert_eq!(
+        format!("{:?}", d4.new_state),
+        "Demoted",
+        "4 failures should demote, not quarantine"
+    );
+    assert_eq!(d4.replay_eligibility, ReplayEligibility::Ineligible);
+
+    // 5 failures → Quarantined
+    let d5 = kernel.evaluate_asset_demotion(
+        "asset-005",
+        ConfidenceState::Active,
+        5,
+        ConfidenceDemotionReasonCode::MaxFailureCountExceeded,
+    );
+    assert_eq!(
+        format!("{:?}", d5.new_state),
+        "Quarantined",
+        "5 failures should escalate to quarantine"
+    );
+    assert!(d5.quarantine_transition);
+    assert!(d5.fail_closed);
+}
+
+#[test]
+fn confidence_revalidation_reason_codes_and_states_are_stable() {
+    // discriminant stability regression — names must not silently change
+    assert_eq!(format!("{:?}", ConfidenceState::Active), "Active");
+    assert_eq!(format!("{:?}", ConfidenceState::Decaying), "Decaying");
+    assert_eq!(
+        format!("{:?}", ConfidenceState::Revalidating),
+        "Revalidating"
+    );
+    assert_eq!(format!("{:?}", ConfidenceState::Demoted), "Demoted");
+    assert_eq!(format!("{:?}", ConfidenceState::Quarantined), "Quarantined");
+    assert_eq!(format!("{:?}", RevalidationOutcome::Passed), "Passed");
+    assert_eq!(format!("{:?}", RevalidationOutcome::Failed), "Failed");
+    assert_eq!(format!("{:?}", RevalidationOutcome::Pending), "Pending");
+    assert_eq!(
+        format!("{:?}", RevalidationOutcome::ErrorFailClosed),
+        "ErrorFailClosed"
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            ConfidenceDemotionReasonCode::ConfidenceDecayThreshold
+        ),
+        "ConfidenceDecayThreshold"
+    );
+    assert_eq!(
+        format!("{:?}", ConfidenceDemotionReasonCode::RepeatedReplayFailure),
+        "RepeatedReplayFailure"
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            ConfidenceDemotionReasonCode::MaxFailureCountExceeded
+        ),
+        "MaxFailureCountExceeded"
+    );
+    assert_eq!(
+        format!("{:?}", ConfidenceDemotionReasonCode::ExplicitRevocation),
+        "ExplicitRevocation"
+    );
+    assert_eq!(
+        format!("{:?}", ConfidenceDemotionReasonCode::UnknownFailClosed),
+        "UnknownFailClosed"
+    );
+    assert_eq!(format!("{:?}", ReplayEligibility::Eligible), "Eligible");
+    assert_eq!(format!("{:?}", ReplayEligibility::Ineligible), "Ineligible");
 }

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.12.3", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.12.4", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -362,3 +362,41 @@ fn semantic_replay_decision_types_resolve() {
     let _class = oris_runtime::agent_contract::TaskEquivalenceClass::Unclassified;
     let _code = oris_runtime::agent_contract::SemanticReplayReasonCode::UnknownFailClosed;
 }
+
+#[test]
+fn confidence_revalidation_decision_types_resolve() {
+    // AUTO-05 wiring gate: ensure ConfidenceState, RevalidationOutcome,
+    // ConfidenceDemotionReasonCode, ReplayEligibility, ConfidenceRevalidationResult,
+    // DemotionDecision, pass_confidence_revalidation, fail_confidence_revalidation,
+    // and demote_asset are reachable via oris_runtime::agent_contract.
+
+    let _passing: oris_runtime::agent_contract::ConfidenceRevalidationResult =
+        oris_runtime::agent_contract::pass_confidence_revalidation(
+            "crv-id-1".to_string(),
+            "asset-id-1".to_string(),
+            oris_runtime::agent_contract::ConfidenceState::Active,
+        );
+
+    let _failing: oris_runtime::agent_contract::ConfidenceRevalidationResult =
+        oris_runtime::agent_contract::fail_confidence_revalidation(
+            "crv-id-2".to_string(),
+            "asset-id-2".to_string(),
+            oris_runtime::agent_contract::ConfidenceState::Decaying,
+            oris_runtime::agent_contract::RevalidationOutcome::Failed,
+        );
+
+    let _demotion: oris_runtime::agent_contract::DemotionDecision =
+        oris_runtime::agent_contract::demote_asset(
+            "dem-id-1".to_string(),
+            "asset-id-3".to_string(),
+            oris_runtime::agent_contract::ConfidenceState::Active,
+            oris_runtime::agent_contract::ConfidenceState::Demoted,
+            oris_runtime::agent_contract::ConfidenceDemotionReasonCode::ConfidenceDecayThreshold,
+        );
+
+    // Variants accessible
+    let _state = oris_runtime::agent_contract::ConfidenceState::Quarantined;
+    let _outcome = oris_runtime::agent_contract::RevalidationOutcome::ErrorFailClosed;
+    let _reason = oris_runtime::agent_contract::ConfidenceDemotionReasonCode::UnknownFailClosed;
+    let _eligibility = oris_runtime::agent_contract::ReplayEligibility::Ineligible;
+}


### PR DESCRIPTION
Closes #269

## Summary
Add continuous confidence revalidation and asset demotion logic to the autonomous evolution pipeline.

## Changes
- oris-agent-contract v0.5.3: New types ConfidenceState, RevalidationOutcome, ConfidenceDemotionReasonCode, ReplayEligibility, ConfidenceRevalidationResult, DemotionDecision with constructors pass_confidence_revalidation, fail_confidence_revalidation, demote_asset
- oris-evokernel v0.12.4: New EvoKernel::evaluate_confidence_revalidation and evaluate_asset_demotion methods; fail-closed at 3+ failures, quarantine escalation at 5+ failures
- oris-runtime v0.37.0: Version bump

## Validation
- cargo fmt --all -- --check passed
- 5 regression tests (confidence_revalidation_*) all pass
- 1 wiring gate test (confidence_revalidation_decision_types_resolve) passes
- cargo test --release --all-features 0 failures
- cargo publish dry-run passed
- Released as oris-runtime v0.37.0
