### PR TITLE
feat(auto-06): bounded autonomous PR lane for low-risk task classes (#270)

### DIFF
--- a/RELEASE_v0.38.0.md
+++ b/RELEASE_v0.38.0.md
@@ -1,0 +1,56 @@
+# Release: oris-runtime v0.38.0
+
+## Summary
+
+Implements **AUTO-06 — Bounded Autonomous PR Lane For Low-Risk Task Classes**.
+
+A narrowly scoped autonomous PR lane is now available for explicitly approved low-risk task classes (`DocsSingleFile`, `LintFix`). The lane gates on validated evidence; all other classes and missing evidence fail closed before any PR payload is assembled.
+
+## New Types (`oris-agent-contract v0.5.4`)
+
+| Type | Kind | Description |
+|------|------|-------------|
+| `AutonomousPrLaneStatus` | `enum` | `PrReady` / `Denied` |
+| `PrLaneApprovalState` | `enum` | `ClassApproved` / `ClassNotApproved` |
+| `AutonomousPrLaneReasonCode` | `enum` | `ApprovedForAutonomousPr`, `TaskClassNotApproved`, `PatchEvidenceMissing`, `ValidationEvidenceMissing`, `RiskTierTooHigh`, `UnknownFailClosed` |
+| `PrEvidenceBundle` | `struct` | Evidence gate: patch summary, validation status, audit trail |
+| `AutonomousPrLaneDecision` | `struct` | Full PR lane decision record with `branch_name`, `pr_payload`, `evidence_bundle` |
+
+## New Constructors (`oris-agent-contract v0.5.4`)
+
+| Constructor | Description |
+|-------------|-------------|
+| `approve_autonomous_pr_lane(…)` | Creates an approved decision with branch and PR payload |
+| `deny_autonomous_pr_lane(…)` | Creates a denied decision, always `fail_closed=true` |
+
+## New Kernel Method (`oris-evokernel v0.12.5`)
+
+| Method | Description |
+|--------|-------------|
+| `EvoKernel::evaluate_autonomous_pr_lane(task_id, task_class, risk_tier, evidence_bundle)` | Gate for the bounded autonomous PR lane |
+
+## Policy
+
+- **Approved classes**: `DocsSingleFile`, `LintFix` at `AutonomousRiskTier::Low` with `validation_passed=true`
+- **All other configurations**: `Denied`, `fail_closed=true`
+
+## Validation
+
+- `cargo fmt --all -- --check` ✓
+- 5 regression tests (`autonomous_pr_lane_*`) — all pass
+- 1 wiring gate test (`autonomous_pr_lane_decision_types_resolve`) — pass
+- `cargo build --all --release --all-features` ✓
+- `cargo test --release --all-features` ✓
+- `cargo publish -p oris-runtime --all-features --dry-run` ✓
+
+## Changed Crates
+
+| Crate | Old | New |
+|-------|-----|-----|
+| `oris-agent-contract` | 0.5.3 | 0.5.4 |
+| `oris-evokernel` | 0.12.4 | 0.12.5 |
+| `oris-runtime` | 0.37.0 | 0.38.0 |
+
+## Linked Issue
+
+Closes #270

--- a/crates/oris-agent-contract/Cargo.toml
+++ b/crates/oris-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-agent-contract"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -1235,6 +1235,139 @@ pub fn deny_semantic_replay(
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// AUTO-06: Bounded Autonomous PR Lane For Low-Risk Task Classes
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Status of an autonomous PR lane decision.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousPrLaneStatus {
+    /// All gates passed; PR can be opened autonomously.
+    PrReady,
+    /// A gate failed or evidence was missing; PR must not be opened.
+    Denied,
+}
+
+/// Approval state for the autonomous PR lane.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PrLaneApprovalState {
+    /// The task class is explicitly approved for autonomous PR creation.
+    ClassApproved,
+    /// The task class is not approved for autonomous PR creation.
+    ClassNotApproved,
+}
+
+/// Reason codes for the autonomous PR lane gate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousPrLaneReasonCode {
+    /// All gates passed; task class is explicitly approved.
+    ApprovedForAutonomousPr,
+    /// Task class is not in the approved low-risk set.
+    TaskClassNotApproved,
+    /// Required patch evidence is absent.
+    PatchEvidenceMissing,
+    /// Validation evidence is missing or incomplete.
+    ValidationEvidenceMissing,
+    /// Risk tier is too high for autonomous PR.
+    RiskTierTooHigh,
+    /// Fail-closed fallback when the reason cannot be determined.
+    UnknownFailClosed,
+}
+
+/// Evidence bundle required before autonomous PR creation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrEvidenceBundle {
+    /// Human-readable summary of the patch.
+    pub patch_summary: String,
+    /// Whether the validation gate has passed for this patch.
+    pub validation_passed: bool,
+    /// Abbreviated audit trail or evidence key list for reviewer inspection.
+    pub audit_trail: Vec<String>,
+}
+
+/// Decision record for the autonomous PR lane.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousPrLaneDecision {
+    /// Unique identifier for this PR lane evaluation.
+    pub pr_lane_id: String,
+    /// Human-readable summary of the delivery decision.
+    pub delivery_summary: String,
+    /// Branch name that would be created; populated only when `pr_ready` is
+    /// `true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_name: Option<String>,
+    /// Structured PR payload (title + body sketch) for the autonomous PR.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_payload: Option<String>,
+    /// Combined evidence bundle governing PR creation eligibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_bundle: Option<PrEvidenceBundle>,
+    /// Whether the PR is ready to be opened.
+    pub pr_ready: bool,
+    /// Gate status.
+    pub delivery_status: AutonomousPrLaneStatus,
+    /// Approval state for the task class.
+    pub approval_state: PrLaneApprovalState,
+    /// Machine-readable reason code.
+    pub reason_code: AutonomousPrLaneReasonCode,
+    /// Safety gate: when `true` the lane must not proceed under any
+    /// circumstance.
+    pub fail_closed: bool,
+}
+
+/// Construct an approved `AutonomousPrLaneDecision`.
+pub fn approve_autonomous_pr_lane(
+    pr_lane_id: impl Into<String>,
+    task_id: impl Into<String>,
+    branch_name: impl Into<String>,
+    evidence_bundle: PrEvidenceBundle,
+) -> AutonomousPrLaneDecision {
+    let task_id: String = task_id.into();
+    let branch = branch_name.into();
+    let pr_payload = format!("Autonomous PR for task {task_id} on branch {branch}");
+    let delivery_summary =
+        format!("autonomous PR lane approved for task {task_id}: branch {branch} ready");
+    AutonomousPrLaneDecision {
+        pr_lane_id: pr_lane_id.into(),
+        delivery_summary,
+        branch_name: Some(branch),
+        pr_payload: Some(pr_payload),
+        evidence_bundle: Some(evidence_bundle),
+        pr_ready: true,
+        delivery_status: AutonomousPrLaneStatus::PrReady,
+        approval_state: PrLaneApprovalState::ClassApproved,
+        reason_code: AutonomousPrLaneReasonCode::ApprovedForAutonomousPr,
+        fail_closed: false,
+    }
+}
+
+/// Construct a denied `AutonomousPrLaneDecision`.
+pub fn deny_autonomous_pr_lane(
+    pr_lane_id: impl Into<String>,
+    task_id: impl Into<String>,
+    reason_code: AutonomousPrLaneReasonCode,
+    detail: impl Into<String>,
+) -> AutonomousPrLaneDecision {
+    let task_id: String = task_id.into();
+    let detail: String = detail.into();
+    let delivery_summary = format!("autonomous PR lane denied for task {task_id}: {detail}");
+    AutonomousPrLaneDecision {
+        pr_lane_id: pr_lane_id.into(),
+        delivery_summary,
+        branch_name: None,
+        pr_payload: None,
+        evidence_bundle: None,
+        pr_ready: false,
+        delivery_status: AutonomousPrLaneStatus::Denied,
+        approval_state: PrLaneApprovalState::ClassNotApproved,
+        reason_code,
+        fail_closed: true,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // AUTO-05: Continuous Confidence Revalidation and Asset Demotion
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -1345,7 +1478,7 @@ pub struct DemotionDecision {
 pub fn pass_confidence_revalidation(
     revalidation_id: impl Into<String>,
     asset_id: impl Into<String>,
-    prior_state: ConfidenceState,
+    _prior_state: ConfidenceState,
 ) -> ConfidenceRevalidationResult {
     let asset_id: String = asset_id.into();
     let summary =

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,7 +11,7 @@ description = "Self-evolving kernel orchestration for Oris."
 anyhow = "1.0"
 async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
-oris-agent-contract = { version = "0.5.3", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.4", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -10,32 +10,34 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
     accept_discovered_candidate, accept_self_evolution_selection_decision,
-    approve_autonomous_mutation_proposal, approve_autonomous_task_plan, approve_semantic_replay,
-    demote_asset, deny_autonomous_mutation_proposal, deny_autonomous_task_plan,
-    deny_discovered_candidate, deny_semantic_replay, fail_confidence_revalidation,
-    infer_mutation_needed_failure_reason_code, infer_replay_fallback_reason_code,
-    normalize_mutation_needed_failure_contract, normalize_replay_fallback_contract,
-    pass_confidence_revalidation, reject_self_evolution_selection_decision, AgentRole,
-    AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
-    AutonomousIntakeOutput, AutonomousIntakeReasonCode, AutonomousMutationProposal,
-    AutonomousPlanReasonCode, AutonomousProposalReasonCode, AutonomousProposalScope,
-    AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass, ConfidenceDemotionReasonCode,
-    ConfidenceRevalidationResult, ConfidenceState, CoordinationMessage, CoordinationPlan,
-    CoordinationPrimitive, CoordinationResult, CoordinationTask, DemotionDecision,
-    DiscoveredCandidate, EquivalenceExplanation, ExecutionFeedback, MutationNeededFailureContract,
-    MutationNeededFailureReasonCode, MutationProposal as AgentMutationProposal,
-    MutationProposalContractReasonCode, MutationProposalEvidence, MutationProposalScope,
-    MutationProposalValidationBudget, ReplayFallbackReasonCode, ReplayFeedback,
-    ReplayPlannerDirective, RevalidationOutcome, SelfEvolutionAcceptanceGateContract,
-    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
-    SelfEvolutionApprovalEvidence, SelfEvolutionAuditConsistencyResult,
-    SelfEvolutionCandidateIntakeRequest, SelfEvolutionDeliveryOutcome,
-    SelfEvolutionMutationProposalContract, SelfEvolutionReasonCodeMatrix,
-    SelfEvolutionSelectionDecision, SelfEvolutionSelectionReasonCode, SemanticReplayDecision,
-    SemanticReplayReasonCode, SupervisedDeliveryApprovalState, SupervisedDeliveryContract,
-    SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
-    SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
-    SupervisedExecutionReasonCode, SupervisedValidationOutcome, TaskEquivalenceClass,
+    approve_autonomous_mutation_proposal, approve_autonomous_pr_lane, approve_autonomous_task_plan,
+    approve_semantic_replay, demote_asset, deny_autonomous_mutation_proposal,
+    deny_autonomous_pr_lane, deny_autonomous_task_plan, deny_discovered_candidate,
+    deny_semantic_replay, fail_confidence_revalidation, infer_mutation_needed_failure_reason_code,
+    infer_replay_fallback_reason_code, normalize_mutation_needed_failure_contract,
+    normalize_replay_fallback_contract, pass_confidence_revalidation,
+    reject_self_evolution_selection_decision, AgentRole, AutonomousApprovalMode,
+    AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeOutput,
+    AutonomousIntakeReasonCode, AutonomousMutationProposal, AutonomousPlanReasonCode,
+    AutonomousPrLaneDecision, AutonomousPrLaneReasonCode, AutonomousProposalReasonCode,
+    AutonomousProposalScope, AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass,
+    ConfidenceDemotionReasonCode, ConfidenceRevalidationResult, ConfidenceState,
+    CoordinationMessage, CoordinationPlan, CoordinationPrimitive, CoordinationResult,
+    CoordinationTask, DemotionDecision, DiscoveredCandidate, EquivalenceExplanation,
+    ExecutionFeedback, MutationNeededFailureContract, MutationNeededFailureReasonCode,
+    MutationProposal as AgentMutationProposal, MutationProposalContractReasonCode,
+    MutationProposalEvidence, MutationProposalScope, MutationProposalValidationBudget,
+    PrEvidenceBundle, ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
+    RevalidationOutcome, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
+    SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
+    SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
+    SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
+    SelfEvolutionReasonCodeMatrix, SelfEvolutionSelectionDecision,
+    SelfEvolutionSelectionReasonCode, SemanticReplayDecision, SemanticReplayReasonCode,
+    SupervisedDeliveryApprovalState, SupervisedDeliveryContract, SupervisedDeliveryReasonCode,
+    SupervisedDeliveryStatus, SupervisedDevloopOutcome, SupervisedDevloopRequest,
+    SupervisedDevloopStatus, SupervisedExecutionDecision, SupervisedExecutionReasonCode,
+    SupervisedValidationOutcome, TaskEquivalenceClass,
 };
 use oris_economics::{EconomicsSignal, EvuLedger, StakePolicy};
 use oris_evolution::{
@@ -3579,6 +3581,23 @@ impl<S: KernelState> EvoKernel<S> {
         asset_demotion_decision(asset_id, prior_state, failure_count, reason_code)
     }
 
+    /// Evaluate whether a task is eligible for the bounded autonomous PR lane.
+    ///
+    /// This is the `EVO26-AUTO-06` autonomous PR lane entry point.
+    ///
+    /// Low-risk classes (`DocFix`, `StaticAnalysisFix`, `FormattingFix`) with
+    /// validated evidence are approved.  All other classes, or tasks that are
+    /// missing evidence, are denied fail-closed.
+    pub fn evaluate_autonomous_pr_lane(
+        &self,
+        task_id: impl Into<String>,
+        task_class: &BoundedTaskClass,
+        risk_tier: AutonomousRiskTier,
+        evidence_bundle: Option<PrEvidenceBundle>,
+    ) -> AutonomousPrLaneDecision {
+        autonomous_pr_lane_decision(task_id, task_class, risk_tier, evidence_bundle)
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5681,6 +5700,74 @@ fn semantic_replay_for_class(
                 explanation.task_equivalence_class
             ),
         )
+    }
+}
+
+/// Autonomous PR lane gate logic.
+///
+/// Approves (`DocFix`, `StaticAnalysisFix`, `FormattingFix`) tasks at low risk
+/// that carry a validated evidence bundle.  All other configurations are denied
+/// fail-closed.
+fn autonomous_pr_lane_decision(
+    task_id: impl Into<String>,
+    task_class: &BoundedTaskClass,
+    risk_tier: AutonomousRiskTier,
+    evidence_bundle: Option<PrEvidenceBundle>,
+) -> AutonomousPrLaneDecision {
+    let task_id: String = task_id.into();
+    let pr_lane_id = next_id("prl");
+
+    // Only low-risk bounded classes are approved for the autonomous PR lane:
+    // single-file docs and lint/formatting fixes.
+    let class_approved = matches!(
+        task_class,
+        BoundedTaskClass::DocsSingleFile | BoundedTaskClass::LintFix
+    );
+
+    // Risk tier must be low.
+    let risk_ok = matches!(risk_tier, AutonomousRiskTier::Low);
+
+    if !class_approved {
+        return deny_autonomous_pr_lane(
+            pr_lane_id,
+            task_id,
+            AutonomousPrLaneReasonCode::TaskClassNotApproved,
+            format!(
+                "task class {:?} is not approved for autonomous PR lane",
+                task_class
+            ),
+        );
+    }
+
+    if !risk_ok {
+        return deny_autonomous_pr_lane(
+            pr_lane_id,
+            task_id,
+            AutonomousPrLaneReasonCode::RiskTierTooHigh,
+            format!(
+                "risk tier {:?} exceeds the autonomous PR lane limit",
+                risk_tier
+            ),
+        );
+    }
+
+    match evidence_bundle {
+        Some(bundle) if bundle.validation_passed => {
+            let branch = format!("auto/{task_id}");
+            approve_autonomous_pr_lane(pr_lane_id, task_id, branch, bundle)
+        }
+        Some(_) => deny_autonomous_pr_lane(
+            pr_lane_id,
+            task_id,
+            AutonomousPrLaneReasonCode::ValidationEvidenceMissing,
+            "validation did not pass for the provided evidence bundle",
+        ),
+        None => deny_autonomous_pr_lane(
+            pr_lane_id,
+            task_id,
+            AutonomousPrLaneReasonCode::PatchEvidenceMissing,
+            "no evidence bundle was provided",
+        ),
     }
 }
 

--- a/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
+++ b/crates/oris-evokernel/tests/evolution_lifecycle_regression.rs
@@ -11,12 +11,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use chrono::{Duration, Utc};
 use oris_agent_contract::{
     AgentTask, AutonomousApprovalMode, AutonomousCandidateSource, AutonomousIntakeInput,
-    AutonomousIntakeReasonCode, AutonomousPlanReasonCode, AutonomousProposalReasonCode,
-    AutonomousRiskTier, BoundedTaskClass, ConfidenceDemotionReasonCode, ConfidenceState,
-    HumanApproval, MutationNeededFailureReasonCode, MutationProposal,
-    MutationProposalContractReasonCode, MutationProposalEvidence, ReplayEligibility,
-    ReplayFallbackNextAction, ReplayFallbackReasonCode, ReplayPlannerDirective,
-    RevalidationOutcome, SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
+    AutonomousIntakeReasonCode, AutonomousPlanReasonCode, AutonomousPrLaneReasonCode,
+    AutonomousPrLaneStatus, AutonomousProposalReasonCode, AutonomousRiskTier, BoundedTaskClass,
+    ConfidenceDemotionReasonCode, ConfidenceState, HumanApproval, MutationNeededFailureReasonCode,
+    MutationProposal, MutationProposalContractReasonCode, MutationProposalEvidence,
+    PrEvidenceBundle, PrLaneApprovalState, ReplayEligibility, ReplayFallbackNextAction,
+    ReplayFallbackReasonCode, ReplayPlannerDirective, RevalidationOutcome,
+    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
     SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
     SelfEvolutionSelectionReasonCode, SemanticReplayReasonCode, SupervisedDeliveryApprovalState,
     SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
@@ -4202,4 +4203,139 @@ fn confidence_revalidation_reason_codes_and_states_are_stable() {
     );
     assert_eq!(format!("{:?}", ReplayEligibility::Eligible), "Eligible");
     assert_eq!(format!("{:?}", ReplayEligibility::Ineligible), "Ineligible");
+}
+
+// ─── AUTO-06: Bounded Autonomous PR Lane ────────────────────────────────────
+
+fn make_evidence(validation_passed: bool) -> PrEvidenceBundle {
+    PrEvidenceBundle {
+        patch_summary: "test patch".to_string(),
+        validation_passed,
+        audit_trail: vec!["evidence-key-1".to_string()],
+    }
+}
+
+#[test]
+fn autonomous_pr_lane_approved_for_docs_single_file_with_valid_evidence() {
+    let kernel = make_evo_kernel_for_autonomous_intake("prl_docs_single");
+    let decision = kernel.evaluate_autonomous_pr_lane(
+        "task-docs-001",
+        &BoundedTaskClass::DocsSingleFile,
+        AutonomousRiskTier::Low,
+        Some(make_evidence(true)),
+    );
+    assert!(
+        decision.pr_ready,
+        "DocsSingleFile low-risk with evidence should be approved"
+    );
+    assert!(!decision.fail_closed);
+    assert_eq!(decision.delivery_status, AutonomousPrLaneStatus::PrReady);
+    assert_eq!(decision.approval_state, PrLaneApprovalState::ClassApproved);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousPrLaneReasonCode::ApprovedForAutonomousPr
+    );
+    assert!(
+        decision.branch_name.is_some(),
+        "approved lane must provide a branch name"
+    );
+    assert!(
+        decision.evidence_bundle.is_some(),
+        "approved lane must carry evidence bundle"
+    );
+}
+
+#[test]
+fn autonomous_pr_lane_approved_for_lint_fix_with_valid_evidence() {
+    let kernel = make_evo_kernel_for_autonomous_intake("prl_lint_fix");
+    let decision = kernel.evaluate_autonomous_pr_lane(
+        "task-lint-001",
+        &BoundedTaskClass::LintFix,
+        AutonomousRiskTier::Low,
+        Some(make_evidence(true)),
+    );
+    assert!(decision.pr_ready);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousPrLaneReasonCode::ApprovedForAutonomousPr
+    );
+}
+
+#[test]
+fn autonomous_pr_lane_denied_for_high_risk_class() {
+    let kernel = make_evo_kernel_for_autonomous_intake("prl_high_risk");
+    let decision = kernel.evaluate_autonomous_pr_lane(
+        "task-dep-001",
+        &BoundedTaskClass::CargoDepUpgrade,
+        AutonomousRiskTier::Medium,
+        Some(make_evidence(true)),
+    );
+    assert!(!decision.pr_ready, "CargoDepUpgrade should be denied");
+    assert!(decision.fail_closed);
+    assert_eq!(decision.delivery_status, AutonomousPrLaneStatus::Denied);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousPrLaneReasonCode::TaskClassNotApproved
+    );
+}
+
+#[test]
+fn autonomous_pr_lane_denied_when_validation_not_passed() {
+    let kernel = make_evo_kernel_for_autonomous_intake("prl_val_fail");
+    let decision = kernel.evaluate_autonomous_pr_lane(
+        "task-docs-002",
+        &BoundedTaskClass::DocsSingleFile,
+        AutonomousRiskTier::Low,
+        Some(make_evidence(false)),
+    );
+    assert!(
+        !decision.pr_ready,
+        "should be denied when validation did not pass"
+    );
+    assert!(decision.fail_closed);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousPrLaneReasonCode::ValidationEvidenceMissing
+    );
+}
+
+#[test]
+fn autonomous_pr_lane_reason_codes_and_statuses_are_stable() {
+    assert_eq!(
+        format!("{:?}", AutonomousPrLaneReasonCode::ApprovedForAutonomousPr),
+        "ApprovedForAutonomousPr"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousPrLaneReasonCode::TaskClassNotApproved),
+        "TaskClassNotApproved"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousPrLaneReasonCode::PatchEvidenceMissing),
+        "PatchEvidenceMissing"
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            AutonomousPrLaneReasonCode::ValidationEvidenceMissing
+        ),
+        "ValidationEvidenceMissing"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousPrLaneReasonCode::RiskTierTooHigh),
+        "RiskTierTooHigh"
+    );
+    assert_eq!(
+        format!("{:?}", AutonomousPrLaneReasonCode::UnknownFailClosed),
+        "UnknownFailClosed"
+    );
+    assert_eq!(format!("{:?}", AutonomousPrLaneStatus::PrReady), "PrReady");
+    assert_eq!(format!("{:?}", AutonomousPrLaneStatus::Denied), "Denied");
+    assert_eq!(
+        format!("{:?}", PrLaneApprovalState::ClassApproved),
+        "ClassApproved"
+    );
+    assert_eq!(
+        format!("{:?}", PrLaneApprovalState::ClassNotApproved),
+        "ClassNotApproved"
+    );
 }

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.12.4", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.12.5", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -400,3 +400,38 @@ fn confidence_revalidation_decision_types_resolve() {
     let _reason = oris_runtime::agent_contract::ConfidenceDemotionReasonCode::UnknownFailClosed;
     let _eligibility = oris_runtime::agent_contract::ReplayEligibility::Ineligible;
 }
+
+#[test]
+fn autonomous_pr_lane_decision_types_resolve() {
+    // AUTO-06 wiring gate: ensure AutonomousPrLaneStatus, PrLaneApprovalState,
+    // AutonomousPrLaneReasonCode, PrEvidenceBundle, AutonomousPrLaneDecision,
+    // approve_autonomous_pr_lane, and deny_autonomous_pr_lane are reachable
+    // via oris_runtime::agent_contract.
+
+    let bundle = oris_runtime::agent_contract::PrEvidenceBundle {
+        patch_summary: "fix lint warnings".to_string(),
+        validation_passed: true,
+        audit_trail: vec!["audit-key-1".to_string()],
+    };
+
+    let _approved: oris_runtime::agent_contract::AutonomousPrLaneDecision =
+        oris_runtime::agent_contract::approve_autonomous_pr_lane(
+            "prl-id-1".to_string(),
+            "task-id-1".to_string(),
+            "auto/task-id-1".to_string(),
+            bundle,
+        );
+
+    let _denied: oris_runtime::agent_contract::AutonomousPrLaneDecision =
+        oris_runtime::agent_contract::deny_autonomous_pr_lane(
+            "prl-id-2".to_string(),
+            "task-id-2".to_string(),
+            oris_runtime::agent_contract::AutonomousPrLaneReasonCode::TaskClassNotApproved,
+            "task class not in approved set",
+        );
+
+    // Variants accessible
+    let _status = oris_runtime::agent_contract::AutonomousPrLaneStatus::Denied;
+    let _approval = oris_runtime::agent_contract::PrLaneApprovalState::ClassNotApproved;
+    let _reason = oris_runtime::agent_contract::AutonomousPrLaneReasonCode::UnknownFailClosed;
+}


### PR DESCRIPTION
Closes #270

## Summary
Add bounded autonomous PR lane support for low-risk task classes (DocsSingleFile, LintFix), with fail-closed policy for all other classes.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p oris-evokernel autonomous_pr_lane_` — 5 tests passing
- `cargo test -p oris-runtime --test evolution_feature_wiring autonomous_pr_lane_decision_types_resolve` passed
- `cargo publish -p oris-runtime --all-features --dry-run` passed
- Released as oris-runtime v0.38.0