### PR TITLE
feat(auto-07): fail-closed autonomous merge and release gate for narrow safe lanes (#271)

### DIFF
--- a/RELEASE_v0.39.0.md
+++ b/RELEASE_v0.39.0.md
@@ -1,0 +1,42 @@
+# Release v0.39.0
+
+## Summary
+
+EVO26-AUTO-07: Fail-Closed Autonomous Merge and Release Gate For Narrow Safe Lanes.
+
+## Changes
+
+### `oris-agent-contract` v0.5.5
+
+- Added `AutonomousMergeGateStatus` enum: `MergeApproved`, `MergeBlocked`
+- Added `AutonomousReleaseGateStatus` enum: `ReleaseApproved`, `ReleaseBlocked`
+- Added `AutonomousPublishGateStatus` enum: `PublishApproved`, `PublishBlocked`
+- Added `KillSwitchState` enum: `Inactive`, `Active`
+- Added `AutonomousReleaseReasonCode` enum with 7 reason codes
+- Added `RollbackPlan` struct
+- Added `AutonomousReleaseGateDecision` struct (machine-readable gate decision record)
+- Added `approve_autonomous_release_gate()` constructor
+- Added `deny_autonomous_release_gate()` constructor
+
+### `oris-evokernel` v0.12.6
+
+- Added `EvoKernel::evaluate_autonomous_release_gate()` public method
+- Added `autonomous_release_gate_decision()` private helper (fail-closed policy: only `DocsSingleFile` and `LintFix` at `Low` risk tier with inactive kill switch and complete evidence are approved)
+
+### `oris-orchestrator` v0.3.2
+
+- Updated `oris-agent-contract` dependency to v0.5.5
+- Added `tests/autonomous_release_gate.rs` with 5 regression tests
+
+### `oris-runtime` v0.39.0
+
+- Updated `oris-evokernel` dependency to v0.12.6
+- Added `autonomous_release_gate_decision_types_resolve` wiring gate test
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo test -p oris-orchestrator autonomous_release_ -- --nocapture` — 5 tests passing
+- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental autonomous_release_gate_decision_types_resolve` — passing
+- `cargo test --release --all-features` — 0 failures
+- `cargo publish -p oris-runtime --all-features --dry-run` — passed

--- a/crates/oris-agent-contract/Cargo.toml
+++ b/crates/oris-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-agent-contract"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-agent-contract/src/lib.rs
+++ b/crates/oris-agent-contract/src/lib.rs
@@ -1235,6 +1235,153 @@ pub fn deny_semantic_replay(
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// AUTO-07: Fail-Closed Autonomous Merge and Release Gate For Narrow Safe Lanes
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Status of the autonomous merge gate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousMergeGateStatus {
+    /// All merge gate checks passed; merge may proceed.
+    MergeApproved,
+    /// A merge gate check failed or evidence was missing; merge must not
+    /// proceed.
+    MergeBlocked,
+}
+
+/// Status of the autonomous release gate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousReleaseGateStatus {
+    /// All release gate checks passed; release may proceed.
+    ReleaseApproved,
+    /// A release gate check failed; release must not proceed.
+    ReleaseBlocked,
+}
+
+/// Status of the autonomous publish gate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousPublishGateStatus {
+    /// All publish gate checks passed; publish may proceed.
+    PublishApproved,
+    /// A publish gate check failed; publish must not proceed.
+    PublishBlocked,
+}
+
+/// Kill-switch state for the autonomous release lane.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum KillSwitchState {
+    /// Kill switch is not active; lane may continue.
+    Inactive,
+    /// Kill switch is active; lane must halt immediately.
+    Active,
+}
+
+/// Reason codes for the autonomous release gate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousReleaseReasonCode {
+    /// All gates passed; autonomous release is approved.
+    ApprovedForAutonomousRelease,
+    /// Task class is not in the approved narrow safe set.
+    TaskClassNotApproved,
+    /// Evidence is incomplete or missing from a prior stage.
+    IncompleteStageEvidence,
+    /// Kill switch is active; lane must halt.
+    KillSwitchActive,
+    /// Risk tier exceeds policy boundary.
+    RiskTierTooHigh,
+    /// Post-gate drift detected; rollback required.
+    PostGateDriftDetected,
+    /// Fail-closed fallback when reason cannot be determined.
+    UnknownFailClosed,
+}
+
+/// Rollback plan attached to a blocked or drifted autonomous release.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RollbackPlan {
+    /// Identifier for the rollback action.
+    pub rollback_id: String,
+    /// Human-readable description of the rollback steps.
+    pub description: String,
+    /// Whether the rollback is immediately actionable.
+    pub actionable: bool,
+}
+
+/// Combined gate decision record for the autonomous merge and release lane.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousReleaseGateDecision {
+    /// Unique identifier for this gate evaluation.
+    pub gate_id: String,
+    /// Human-readable summary of the gate decision.
+    pub gate_summary: String,
+    /// Result of the merge gate check.
+    pub merge_gate_result: AutonomousMergeGateStatus,
+    /// Result of the release gate check.
+    pub release_gate_result: AutonomousReleaseGateStatus,
+    /// Result of the publish gate check.
+    pub publish_gate_result: AutonomousPublishGateStatus,
+    /// Current kill-switch state at evaluation time.
+    pub kill_switch_state: KillSwitchState,
+    /// Rollback plan; populated when any gate is blocked or drift detected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollback_plan: Option<RollbackPlan>,
+    /// Machine-readable reason code.
+    pub reason_code: AutonomousReleaseReasonCode,
+    /// Safety gate: when `true` the lane must not proceed under any
+    /// circumstance.
+    pub fail_closed: bool,
+}
+
+/// Construct an approved `AutonomousReleaseGateDecision`.
+pub fn approve_autonomous_release_gate(
+    gate_id: impl Into<String>,
+    task_id: impl Into<String>,
+) -> AutonomousReleaseGateDecision {
+    let task_id: String = task_id.into();
+    let gate_summary =
+        format!("autonomous release gate approved for task {task_id}: all gates passed");
+    AutonomousReleaseGateDecision {
+        gate_id: gate_id.into(),
+        gate_summary,
+        merge_gate_result: AutonomousMergeGateStatus::MergeApproved,
+        release_gate_result: AutonomousReleaseGateStatus::ReleaseApproved,
+        publish_gate_result: AutonomousPublishGateStatus::PublishApproved,
+        kill_switch_state: KillSwitchState::Inactive,
+        rollback_plan: None,
+        reason_code: AutonomousReleaseReasonCode::ApprovedForAutonomousRelease,
+        fail_closed: false,
+    }
+}
+
+/// Construct a denied `AutonomousReleaseGateDecision`.
+pub fn deny_autonomous_release_gate(
+    gate_id: impl Into<String>,
+    task_id: impl Into<String>,
+    reason_code: AutonomousReleaseReasonCode,
+    kill_switch_state: KillSwitchState,
+    detail: impl Into<String>,
+    rollback_plan: Option<RollbackPlan>,
+) -> AutonomousReleaseGateDecision {
+    let task_id: String = task_id.into();
+    let detail: String = detail.into();
+    let gate_summary = format!("autonomous release gate denied for task {task_id}: {detail}");
+    AutonomousReleaseGateDecision {
+        gate_id: gate_id.into(),
+        gate_summary,
+        merge_gate_result: AutonomousMergeGateStatus::MergeBlocked,
+        release_gate_result: AutonomousReleaseGateStatus::ReleaseBlocked,
+        publish_gate_result: AutonomousPublishGateStatus::PublishBlocked,
+        kill_switch_state,
+        rollback_plan,
+        reason_code,
+        fail_closed: true,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // AUTO-06: Bounded Autonomous PR Lane For Low-Risk Task Classes
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,7 +11,7 @@ description = "Self-evolving kernel orchestration for Oris."
 anyhow = "1.0"
 async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
-oris-agent-contract = { version = "0.5.4", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }

--- a/crates/oris-evokernel/src/core.rs
+++ b/crates/oris-evokernel/src/core.rs
@@ -10,9 +10,10 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use oris_agent_contract::{
     accept_discovered_candidate, accept_self_evolution_selection_decision,
-    approve_autonomous_mutation_proposal, approve_autonomous_pr_lane, approve_autonomous_task_plan,
-    approve_semantic_replay, demote_asset, deny_autonomous_mutation_proposal,
-    deny_autonomous_pr_lane, deny_autonomous_task_plan, deny_discovered_candidate,
+    approve_autonomous_mutation_proposal, approve_autonomous_pr_lane,
+    approve_autonomous_release_gate, approve_autonomous_task_plan, approve_semantic_replay,
+    demote_asset, deny_autonomous_mutation_proposal, deny_autonomous_pr_lane,
+    deny_autonomous_release_gate, deny_autonomous_task_plan, deny_discovered_candidate,
     deny_semantic_replay, fail_confidence_revalidation, infer_mutation_needed_failure_reason_code,
     infer_replay_fallback_reason_code, normalize_mutation_needed_failure_contract,
     normalize_replay_fallback_contract, pass_confidence_revalidation,
@@ -20,24 +21,25 @@ use oris_agent_contract::{
     AutonomousCandidateSource, AutonomousIntakeInput, AutonomousIntakeOutput,
     AutonomousIntakeReasonCode, AutonomousMutationProposal, AutonomousPlanReasonCode,
     AutonomousPrLaneDecision, AutonomousPrLaneReasonCode, AutonomousProposalReasonCode,
-    AutonomousProposalScope, AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass,
-    ConfidenceDemotionReasonCode, ConfidenceRevalidationResult, ConfidenceState,
-    CoordinationMessage, CoordinationPlan, CoordinationPrimitive, CoordinationResult,
-    CoordinationTask, DemotionDecision, DiscoveredCandidate, EquivalenceExplanation,
-    ExecutionFeedback, MutationNeededFailureContract, MutationNeededFailureReasonCode,
+    AutonomousProposalScope, AutonomousReleaseGateDecision, AutonomousReleaseReasonCode,
+    AutonomousRiskTier, AutonomousTaskPlan, BoundedTaskClass, ConfidenceDemotionReasonCode,
+    ConfidenceRevalidationResult, ConfidenceState, CoordinationMessage, CoordinationPlan,
+    CoordinationPrimitive, CoordinationResult, CoordinationTask, DemotionDecision,
+    DiscoveredCandidate, EquivalenceExplanation, ExecutionFeedback, KillSwitchState,
+    MutationNeededFailureContract, MutationNeededFailureReasonCode,
     MutationProposal as AgentMutationProposal, MutationProposalContractReasonCode,
     MutationProposalEvidence, MutationProposalScope, MutationProposalValidationBudget,
     PrEvidenceBundle, ReplayFallbackReasonCode, ReplayFeedback, ReplayPlannerDirective,
-    RevalidationOutcome, SelfEvolutionAcceptanceGateContract, SelfEvolutionAcceptanceGateInput,
-    SelfEvolutionAcceptanceGateReasonCode, SelfEvolutionApprovalEvidence,
-    SelfEvolutionAuditConsistencyResult, SelfEvolutionCandidateIntakeRequest,
-    SelfEvolutionDeliveryOutcome, SelfEvolutionMutationProposalContract,
-    SelfEvolutionReasonCodeMatrix, SelfEvolutionSelectionDecision,
-    SelfEvolutionSelectionReasonCode, SemanticReplayDecision, SemanticReplayReasonCode,
-    SupervisedDeliveryApprovalState, SupervisedDeliveryContract, SupervisedDeliveryReasonCode,
-    SupervisedDeliveryStatus, SupervisedDevloopOutcome, SupervisedDevloopRequest,
-    SupervisedDevloopStatus, SupervisedExecutionDecision, SupervisedExecutionReasonCode,
-    SupervisedValidationOutcome, TaskEquivalenceClass,
+    RevalidationOutcome, RollbackPlan, SelfEvolutionAcceptanceGateContract,
+    SelfEvolutionAcceptanceGateInput, SelfEvolutionAcceptanceGateReasonCode,
+    SelfEvolutionApprovalEvidence, SelfEvolutionAuditConsistencyResult,
+    SelfEvolutionCandidateIntakeRequest, SelfEvolutionDeliveryOutcome,
+    SelfEvolutionMutationProposalContract, SelfEvolutionReasonCodeMatrix,
+    SelfEvolutionSelectionDecision, SelfEvolutionSelectionReasonCode, SemanticReplayDecision,
+    SemanticReplayReasonCode, SupervisedDeliveryApprovalState, SupervisedDeliveryContract,
+    SupervisedDeliveryReasonCode, SupervisedDeliveryStatus, SupervisedDevloopOutcome,
+    SupervisedDevloopRequest, SupervisedDevloopStatus, SupervisedExecutionDecision,
+    SupervisedExecutionReasonCode, SupervisedValidationOutcome, TaskEquivalenceClass,
 };
 use oris_economics::{EconomicsSignal, EvuLedger, StakePolicy};
 use oris_evolution::{
@@ -3598,6 +3600,31 @@ impl<S: KernelState> EvoKernel<S> {
         autonomous_pr_lane_decision(task_id, task_class, risk_tier, evidence_bundle)
     }
 
+    /// Evaluate whether a task is eligible for the fail-closed autonomous merge
+    /// and release gate.
+    ///
+    /// This is the `EVO26-AUTO-07` autonomous release gate entry point.
+    ///
+    /// Only low-risk bounded classes (`DocsSingleFile`, `LintFix`) with a
+    /// complete evidence chain, an inactive kill switch, and a `Low` risk tier
+    /// are approved.  All other configurations are denied fail-closed.
+    pub fn evaluate_autonomous_release_gate(
+        &self,
+        task_id: impl Into<String>,
+        task_class: &BoundedTaskClass,
+        risk_tier: AutonomousRiskTier,
+        kill_switch_state: KillSwitchState,
+        evidence_complete: bool,
+    ) -> AutonomousReleaseGateDecision {
+        autonomous_release_gate_decision(
+            task_id,
+            task_class,
+            risk_tier,
+            kill_switch_state,
+            evidence_complete,
+        )
+    }
+
     pub fn select_self_evolution_candidate(
         &self,
         request: &SelfEvolutionCandidateIntakeRequest,
@@ -5708,6 +5735,88 @@ fn semantic_replay_for_class(
 /// Approves (`DocFix`, `StaticAnalysisFix`, `FormattingFix`) tasks at low risk
 /// that carry a validated evidence bundle.  All other configurations are denied
 /// fail-closed.
+fn autonomous_release_gate_decision(
+    task_id: impl Into<String>,
+    task_class: &BoundedTaskClass,
+    risk_tier: AutonomousRiskTier,
+    kill_switch_state: KillSwitchState,
+    evidence_complete: bool,
+) -> AutonomousReleaseGateDecision {
+    let task_id: String = task_id.into();
+    let gate_id = next_id("rgl");
+
+    // Kill switch must be inactive before any other check.
+    if matches!(kill_switch_state, KillSwitchState::Active) {
+        let rollback = RollbackPlan {
+            rollback_id: next_id("rbk"),
+            description: format!("kill switch active: halt release for task {task_id}"),
+            actionable: true,
+        };
+        return deny_autonomous_release_gate(
+            gate_id,
+            task_id,
+            AutonomousReleaseReasonCode::KillSwitchActive,
+            kill_switch_state,
+            "kill switch is active",
+            Some(rollback),
+        );
+    }
+
+    // Only low-risk bounded classes are approved for the autonomous release gate.
+    let class_approved = matches!(
+        task_class,
+        BoundedTaskClass::DocsSingleFile | BoundedTaskClass::LintFix
+    );
+
+    if !class_approved {
+        return deny_autonomous_release_gate(
+            gate_id,
+            task_id,
+            AutonomousReleaseReasonCode::TaskClassNotApproved,
+            KillSwitchState::Inactive,
+            format!(
+                "task class {:?} is not approved for autonomous release",
+                task_class
+            ),
+            None,
+        );
+    }
+
+    // Risk tier must be low.
+    if !matches!(risk_tier, AutonomousRiskTier::Low) {
+        return deny_autonomous_release_gate(
+            gate_id,
+            task_id,
+            AutonomousReleaseReasonCode::RiskTierTooHigh,
+            KillSwitchState::Inactive,
+            format!(
+                "risk tier {:?} exceeds policy boundary for autonomous release",
+                risk_tier
+            ),
+            None,
+        );
+    }
+
+    // All prior stage evidence must be present and complete.
+    if !evidence_complete {
+        let rollback = RollbackPlan {
+            rollback_id: next_id("rbk"),
+            description: format!("incomplete evidence: cannot release task {task_id}"),
+            actionable: false,
+        };
+        return deny_autonomous_release_gate(
+            gate_id,
+            task_id,
+            AutonomousReleaseReasonCode::IncompleteStageEvidence,
+            KillSwitchState::Inactive,
+            "evidence from a prior stage is incomplete or missing",
+            Some(rollback),
+        );
+    }
+
+    approve_autonomous_release_gate(gate_id, task_id)
+}
+
 fn autonomous_pr_lane_decision(
     task_id: impl Into<String>,
     task_class: &BoundedTaskClass,

--- a/crates/oris-orchestrator/Cargo.toml
+++ b/crates/oris-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-orchestrator"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"
@@ -8,7 +8,7 @@ description = "Oris orchestration contracts and control flow primitives."
 
 [dependencies]
 async-trait = "0.1"
-oris-agent-contract = { version = "0.5.0", path = "../oris-agent-contract" }
+oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
 oris-intake = { version = "0.2.0", path = "../oris-intake" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/oris-orchestrator/tests/autonomous_release_gate.rs
+++ b/crates/oris-orchestrator/tests/autonomous_release_gate.rs
@@ -1,0 +1,121 @@
+use oris_agent_contract::{
+    approve_autonomous_release_gate, deny_autonomous_release_gate, AutonomousMergeGateStatus,
+    AutonomousPublishGateStatus, AutonomousReleaseGateStatus, AutonomousReleaseReasonCode,
+    KillSwitchState, RollbackPlan,
+};
+
+fn make_rollback(id: &str) -> RollbackPlan {
+    RollbackPlan {
+        rollback_id: id.to_string(),
+        description: format!("rollback for {id}"),
+        actionable: true,
+    }
+}
+
+#[test]
+fn autonomous_release_gate_approved_for_docs_single_file() {
+    let decision = approve_autonomous_release_gate("gate-1", "task-1");
+    assert_eq!(
+        decision.merge_gate_result,
+        AutonomousMergeGateStatus::MergeApproved
+    );
+    assert_eq!(
+        decision.release_gate_result,
+        AutonomousReleaseGateStatus::ReleaseApproved
+    );
+    assert_eq!(
+        decision.publish_gate_result,
+        AutonomousPublishGateStatus::PublishApproved
+    );
+    assert_eq!(decision.kill_switch_state, KillSwitchState::Inactive);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousReleaseReasonCode::ApprovedForAutonomousRelease
+    );
+    assert!(!decision.fail_closed);
+    assert!(decision.rollback_plan.is_none());
+}
+
+#[test]
+fn autonomous_release_gate_denied_when_kill_switch_active() {
+    let rollback = make_rollback("rbk-ks");
+    let decision = deny_autonomous_release_gate(
+        "gate-2",
+        "task-2",
+        AutonomousReleaseReasonCode::KillSwitchActive,
+        KillSwitchState::Active,
+        "kill switch is active",
+        Some(rollback),
+    );
+    assert_eq!(
+        decision.merge_gate_result,
+        AutonomousMergeGateStatus::MergeBlocked
+    );
+    assert_eq!(decision.kill_switch_state, KillSwitchState::Active);
+    assert_eq!(
+        decision.reason_code,
+        AutonomousReleaseReasonCode::KillSwitchActive
+    );
+    assert!(decision.fail_closed);
+    assert!(decision.rollback_plan.is_some());
+}
+
+#[test]
+fn autonomous_release_gate_denied_for_unapproved_task_class() {
+    let decision = deny_autonomous_release_gate(
+        "gate-3",
+        "task-3",
+        AutonomousReleaseReasonCode::TaskClassNotApproved,
+        KillSwitchState::Inactive,
+        "task class not approved",
+        None,
+    );
+    assert_eq!(
+        decision.reason_code,
+        AutonomousReleaseReasonCode::TaskClassNotApproved
+    );
+    assert_eq!(
+        decision.publish_gate_result,
+        AutonomousPublishGateStatus::PublishBlocked
+    );
+    assert!(decision.fail_closed);
+    assert!(decision.rollback_plan.is_none());
+}
+
+#[test]
+fn autonomous_release_gate_denied_for_incomplete_evidence() {
+    let rollback = make_rollback("rbk-ev");
+    let decision = deny_autonomous_release_gate(
+        "gate-4",
+        "task-4",
+        AutonomousReleaseReasonCode::IncompleteStageEvidence,
+        KillSwitchState::Inactive,
+        "evidence from a prior stage is incomplete",
+        Some(rollback.clone()),
+    );
+    assert_eq!(
+        decision.reason_code,
+        AutonomousReleaseReasonCode::IncompleteStageEvidence
+    );
+    assert!(decision.fail_closed);
+    assert_eq!(decision.rollback_plan, Some(rollback));
+}
+
+#[test]
+fn autonomous_release_gate_reason_codes_and_statuses_are_stable() {
+    let _ = AutonomousReleaseReasonCode::ApprovedForAutonomousRelease;
+    let _ = AutonomousReleaseReasonCode::TaskClassNotApproved;
+    let _ = AutonomousReleaseReasonCode::IncompleteStageEvidence;
+    let _ = AutonomousReleaseReasonCode::KillSwitchActive;
+    let _ = AutonomousReleaseReasonCode::RiskTierTooHigh;
+    let _ = AutonomousReleaseReasonCode::PostGateDriftDetected;
+    let _ = AutonomousReleaseReasonCode::UnknownFailClosed;
+    let _ = AutonomousMergeGateStatus::MergeApproved;
+    let _ = AutonomousMergeGateStatus::MergeBlocked;
+    let _ = AutonomousReleaseGateStatus::ReleaseApproved;
+    let _ = AutonomousReleaseGateStatus::ReleaseBlocked;
+    let _ = AutonomousPublishGateStatus::PublishApproved;
+    let _ = AutonomousPublishGateStatus::PublishBlocked;
+    let _ = KillSwitchState::Active;
+    let _ = KillSwitchState::Inactive;
+}

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.12.5", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.12.6", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -435,3 +435,40 @@ fn autonomous_pr_lane_decision_types_resolve() {
     let _approval = oris_runtime::agent_contract::PrLaneApprovalState::ClassNotApproved;
     let _reason = oris_runtime::agent_contract::AutonomousPrLaneReasonCode::UnknownFailClosed;
 }
+
+/// Wiring gate: AUTO-07 types and constructors resolve through oris-runtime.
+#[test]
+#[cfg(feature = "full-evolution-experimental")]
+fn autonomous_release_gate_decision_types_resolve() {
+    // approve_autonomous_release_gate and deny_autonomous_release_gate are
+    // reachable via oris_runtime::agent_contract.
+
+    let _approved: oris_runtime::agent_contract::AutonomousReleaseGateDecision =
+        oris_runtime::agent_contract::approve_autonomous_release_gate(
+            "gate-id-1".to_string(),
+            "task-id-1".to_string(),
+        );
+
+    let rollback = oris_runtime::agent_contract::RollbackPlan {
+        rollback_id: "rbk-1".to_string(),
+        description: "halt release".to_string(),
+        actionable: true,
+    };
+
+    let _denied: oris_runtime::agent_contract::AutonomousReleaseGateDecision =
+        oris_runtime::agent_contract::deny_autonomous_release_gate(
+            "gate-id-2".to_string(),
+            "task-id-2".to_string(),
+            oris_runtime::agent_contract::AutonomousReleaseReasonCode::KillSwitchActive,
+            oris_runtime::agent_contract::KillSwitchState::Active,
+            "kill switch is active",
+            Some(rollback),
+        );
+
+    // Variants accessible
+    let _merge = oris_runtime::agent_contract::AutonomousMergeGateStatus::MergeBlocked;
+    let _release = oris_runtime::agent_contract::AutonomousReleaseGateStatus::ReleaseBlocked;
+    let _publish = oris_runtime::agent_contract::AutonomousPublishGateStatus::PublishBlocked;
+    let _kill = oris_runtime::agent_contract::KillSwitchState::Inactive;
+    let _reason = oris_runtime::agent_contract::AutonomousReleaseReasonCode::UnknownFailClosed;
+}


### PR DESCRIPTION
Closes #271

## Summary
Add fail-closed autonomous merge and release gate for narrow safe lanes (DocsSingleFile, LintFix at Low risk tier only), with kill switch, rollback plan, and complete evidence chain requirements before any merge or publish proceeds.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p oris-orchestrator autonomous_release_ -- --nocapture` — 5 tests passing
- `cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental autonomous_release_gate_decision_types_resolve` passed
- `cargo test --release --all-features` — 0 failures
- Released as oris-runtime v0.39.0
