### PR TITLE
feat: Phase 1 - PrometheusIntakeSource, SentryIntakeSource, PostgreSQL priority dispatch, CLI hardening

### DIFF
--- a/crates/oris-execution-runtime/src/postgres_runtime_repository.rs
+++ b/crates/oris-execution-runtime/src/postgres_runtime_repository.rs
@@ -17,7 +17,7 @@ use super::models::{
 };
 use super::repository::RuntimeRepository;
 
-const POSTGRES_RUNTIME_SCHEMA_VERSION: i64 = 4;
+const POSTGRES_RUNTIME_SCHEMA_VERSION: i64 = 5;
 
 fn is_valid_schema_ident(schema: &str) -> bool {
     !schema.is_empty()
@@ -533,6 +533,50 @@ impl PostgresRuntimeRepository {
                     sqlx::query(&sql_record)
                         .bind(4_i32)
                         .bind("runtime_recipes_organisms_sessions_disputes")
+                        .bind(now)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+
+                // Migration v5: priority column on runtime_attempts for ordered dispatch
+                if current_version < 5 {
+                    let sql_add_priority = format!(
+                        "ALTER TABLE \"{}\".runtime_attempts ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0",
+                        schema
+                    );
+                    let sql_idx_priority = format!(
+                        "CREATE INDEX IF NOT EXISTS idx_runtime_attempts_status_priority_retry
+                         ON \"{}\".runtime_attempts(status, priority DESC, retry_at_ms)",
+                        schema
+                    );
+                    let sql_idx_tenant_priority = format!(
+                        "CREATE INDEX IF NOT EXISTS idx_runtime_attempts_tenant_status_priority
+                         ON \"{}\".runtime_attempts(status, priority DESC)",
+                        schema
+                    );
+                    sqlx::query(&sql_add_priority)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    sqlx::query(&sql_idx_priority)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    sqlx::query(&sql_idx_tenant_priority)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let now = dt_to_ms(Utc::now());
+                    let sql_record = format!(
+                        "INSERT INTO \"{}\".runtime_schema_migrations(version, name, applied_at_ms)
+                         VALUES ($1, $2, $3)
+                         ON CONFLICT(version) DO NOTHING",
+                        schema
+                    );
+                    sqlx::query(&sql_record)
+                        .bind(5_i32)
+                        .bind("attempt_priority_dispatch_order")
                         .bind(now)
                         .execute(&pool)
                         .await
@@ -1483,7 +1527,7 @@ impl RuntimeRepository for PostgresRuntimeRepository {
                      a.status = 'queued'
                      OR (a.status = 'retry_backoff' AND (a.retry_at_ms IS NULL OR a.retry_at_ms <= $1))
                    )
-                 ORDER BY a.attempt_no ASC, a.attempt_id ASC
+                 ORDER BY a.priority DESC, a.attempt_no ASC, a.attempt_id ASC
                  LIMIT $2",
                 schema, schema
             );

--- a/crates/oris-intake/src/source.rs
+++ b/crates/oris-intake/src/source.rs
@@ -537,21 +537,114 @@ impl IntakeSource for LogFileIntakeSource {
     }
 }
 
-/// Prometheus/Alertmanager intake source stub.
+/// Prometheus/Alertmanager v4 webhook payload.
 ///
-/// This is intentionally a compile-safe placeholder so downstream callers can
-/// wire the source type today while the concrete alert payload mapping is
-/// implemented in a later issue.
+/// See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+#[derive(Clone, Debug, Deserialize)]
+pub struct AlertmanagerPayload {
+    pub version: Option<String>,
+    pub status: Option<String>,
+    #[serde(rename = "groupLabels")]
+    pub group_labels: Option<std::collections::HashMap<String, String>>,
+    #[serde(rename = "commonLabels")]
+    pub common_labels: Option<std::collections::HashMap<String, String>>,
+    #[serde(rename = "commonAnnotations")]
+    pub common_annotations: Option<std::collections::HashMap<String, String>>,
+    pub alerts: Option<Vec<AlertmanagerAlert>>,
+    #[serde(rename = "externalURL")]
+    pub external_url: Option<String>,
+}
+
+/// Single alert within an Alertmanager payload.
+#[derive(Clone, Debug, Deserialize)]
+pub struct AlertmanagerAlert {
+    pub status: Option<String>,
+    pub labels: Option<std::collections::HashMap<String, String>>,
+    pub annotations: Option<std::collections::HashMap<String, String>>,
+    pub fingerprint: Option<String>,
+}
+
+/// Prometheus/Alertmanager intake source.
+///
+/// Processes Alertmanager webhook v4 payloads and converts firing alerts to
+/// `IntakeEvent` instances. One event is emitted per alert in the payload.
 #[derive(Clone, Debug, Default)]
 pub struct PrometheusIntakeSource;
+
+impl PrometheusIntakeSource {
+    fn alert_severity(labels: &std::collections::HashMap<String, String>) -> IssueSeverity {
+        match labels.get("severity").map(|s| s.as_str()).unwrap_or("") {
+            "critical" | "page" => IssueSeverity::Critical,
+            "warning" | "high" => IssueSeverity::High,
+            "info" | "low" => IssueSeverity::Low,
+            _ => IssueSeverity::Medium,
+        }
+    }
+}
 
 impl IntakeSource for PrometheusIntakeSource {
     fn source_type(&self) -> IntakeSourceType {
         IntakeSourceType::Prometheus
     }
 
-    fn process(&self, _payload: &[u8]) -> IntakeResult<Vec<IntakeEvent>> {
-        todo!("Prometheus alert payload mapping is not implemented yet")
+    fn process(&self, payload: &[u8]) -> IntakeResult<Vec<IntakeEvent>> {
+        let alert_payload: AlertmanagerPayload = serde_json::from_slice(payload)
+            .map_err(|e| IntakeError::ParseError(format!("invalid Alertmanager JSON: {}", e)))?;
+
+        let group_status = alert_payload.status.as_deref().unwrap_or("unknown");
+        let alerts = alert_payload.alerts.unwrap_or_default();
+        let empty_map = std::collections::HashMap::new();
+
+        let events = alerts
+            .into_iter()
+            .filter(|a| a.status.as_deref().unwrap_or("") == "firing")
+            .map(|alert| {
+                let labels = alert.labels.as_ref().unwrap_or(&empty_map);
+                let annotations = alert.annotations.as_ref().unwrap_or(&empty_map);
+                let alert_name = labels
+                    .get("alertname")
+                    .map(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let summary = annotations
+                    .get("summary")
+                    .or_else(|| annotations.get("message"))
+                    .map(|s| s.as_str())
+                    .unwrap_or("Prometheus alert fired");
+                let description = annotations
+                    .get("description")
+                    .or_else(|| annotations.get("runbook_url"))
+                    .map(|s| s.as_str())
+                    .unwrap_or(summary);
+
+                let severity = Self::alert_severity(labels);
+
+                let signals: Vec<String> = labels
+                    .iter()
+                    .map(|(k, v)| format!("label:{}:{}", k, v))
+                    .chain(
+                        alert
+                            .fingerprint
+                            .as_ref()
+                            .map(|fp| format!("fingerprint:{}", fp))
+                            .into_iter(),
+                    )
+                    .collect();
+
+                IntakeEvent {
+                    event_id: uuid::Uuid::new_v4().to_string(),
+                    source_type: IntakeSourceType::Prometheus,
+                    source_event_id: alert.fingerprint.clone(),
+                    title: format!("Alert: {} [{}]", alert_name, group_status),
+                    description: description.to_string(),
+                    severity,
+                    signals,
+                    raw_payload: None,
+                    timestamp_ms: chrono::Utc::now().timestamp_millis(),
+                }
+            })
+            .collect();
+
+        Ok(events)
     }
 
     fn validate(&self, payload: &[u8]) -> IntakeResult<()> {
@@ -561,21 +654,124 @@ impl IntakeSource for PrometheusIntakeSource {
     }
 }
 
-/// Sentry intake source stub.
+/// Minimal Sentry issue alert webhook payload.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryAlertPayload {
+    pub action: Option<String>,
+    pub actor: Option<SentryActor>,
+    pub data: Option<SentryAlertData>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryActor {
+    pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryAlertData {
+    pub issue: Option<SentryIssue>,
+    pub error: Option<SentryError>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryIssue {
+    pub id: Option<String>,
+    pub title: Option<String>,
+    pub level: Option<String>,
+    pub project: Option<SentryProject>,
+    pub permalink: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryProject {
+    pub slug: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SentryError {
+    pub message: Option<String>,
+    pub level: Option<String>,
+}
+
+/// Sentry issue alert intake source.
 ///
-/// This is intentionally a compile-safe placeholder so downstream callers can
-/// depend on the source type now while the concrete Sentry envelope/event
-/// translation is implemented in a later issue.
+/// Handles Sentry issue-alert webhook payloads (action: created/resolved).
+/// Emits one `IntakeEvent` per webhook delivery.
 #[derive(Clone, Debug, Default)]
 pub struct SentryIntakeSource;
+
+impl SentryIntakeSource {
+    fn level_to_severity(level: &str) -> IssueSeverity {
+        match level {
+            "fatal" | "critical" => IssueSeverity::Critical,
+            "error" => IssueSeverity::High,
+            "warning" => IssueSeverity::Medium,
+            "info" | "debug" => IssueSeverity::Low,
+            _ => IssueSeverity::Medium,
+        }
+    }
+}
 
 impl IntakeSource for SentryIntakeSource {
     fn source_type(&self) -> IntakeSourceType {
         IntakeSourceType::Sentry
     }
 
-    fn process(&self, _payload: &[u8]) -> IntakeResult<Vec<IntakeEvent>> {
-        todo!("Sentry event payload mapping is not implemented yet")
+    fn process(&self, payload: &[u8]) -> IntakeResult<Vec<IntakeEvent>> {
+        let alert: SentryAlertPayload = serde_json::from_slice(payload)
+            .map_err(|e| IntakeError::ParseError(format!("invalid Sentry JSON: {}", e)))?;
+
+        let action = alert.action.as_deref().unwrap_or("unknown");
+        // Only process "created" (new error) and "triggered" (alert rule) actions.
+        if !matches!(action, "created" | "triggered") {
+            return Ok(vec![]);
+        }
+
+        let data = alert.data.as_ref();
+        let issue = data.and_then(|d| d.issue.as_ref());
+        let error_data = data.and_then(|d| d.error.as_ref());
+
+        let (title, level, event_id, description) = if let Some(issue) = issue {
+            let lvl = issue.level.as_deref().unwrap_or("error");
+            let project = issue
+                .project
+                .as_ref()
+                .and_then(|p| p.slug.as_deref())
+                .unwrap_or("unknown");
+            let title = issue.title.as_deref().unwrap_or("Sentry issue").to_string();
+            let id = issue.id.clone();
+            let desc = issue
+                .permalink
+                .as_deref()
+                .map(|url| format!("View issue: {}", url))
+                .unwrap_or_else(|| format!("Sentry [{}] {} in project {}", lvl, title, project));
+            (title, lvl.to_string(), id, desc)
+        } else if let Some(err) = error_data {
+            let lvl = err.level.as_deref().unwrap_or("error");
+            let msg = err.message.as_deref().unwrap_or("Sentry error");
+            (msg.to_string(), lvl.to_string(), None, msg.to_string())
+        } else {
+            return Ok(vec![]);
+        };
+
+        let severity = Self::level_to_severity(&level);
+        let signals = vec![
+            format!("sentry_action:{}", action),
+            format!("sentry_level:{}", level),
+        ];
+
+        Ok(vec![IntakeEvent {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            source_type: IntakeSourceType::Sentry,
+            source_event_id: event_id,
+            title: format!("Sentry: {}", title),
+            description,
+            severity,
+            signals,
+            raw_payload: None,
+            timestamp_ms: chrono::Utc::now().timestamp_millis(),
+        }])
     }
 
     fn validate(&self, payload: &[u8]) -> IntakeResult<()> {
@@ -640,5 +836,77 @@ mod tests {
 
         assert!(prometheus.validate(br#"{"alerts":[]}"#).is_ok());
         assert!(sentry.validate(br#"{"event_id":"abc"}"#).is_ok());
+    }
+
+    #[test]
+    fn test_prometheus_intake_source_parses_firing_alert() {
+        let source = PrometheusIntakeSource;
+        let payload = br#"{
+            "version": "4",
+            "status": "firing",
+            "commonLabels": {"severity": "critical"},
+            "commonAnnotations": {"summary": "DB down"},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "DBDown", "severity": "critical"},
+                    "annotations": {"summary": "Database is unreachable"},
+                    "fingerprint": "abc123"
+                },
+                {
+                    "status": "resolved",
+                    "labels": {"alertname": "DBDown", "severity": "critical"},
+                    "annotations": {"summary": "Database is unreachable"},
+                    "fingerprint": "abc124"
+                }
+            ]
+        }"#;
+        let events = source
+            .process(payload)
+            .expect("should parse alertmanager payload");
+        // Only firing alerts should produce events
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].severity, IssueSeverity::Critical);
+        assert!(events[0].title.contains("DBDown"));
+        assert_eq!(events[0].source_type, IntakeSourceType::Prometheus);
+        assert_eq!(events[0].source_event_id, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_prometheus_intake_source_empty_alerts() {
+        let source = PrometheusIntakeSource;
+        let payload = br#"{"version":"4","status":"resolved","alerts":[]}"#;
+        let events = source.process(payload).expect("empty alerts ok");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_sentry_intake_source_parses_issue_created() {
+        let source = SentryIntakeSource;
+        let payload = br#"{
+            "action": "created",
+            "data": {
+                "issue": {
+                    "id": "sentry-issue-1",
+                    "title": "ZeroDivisionError",
+                    "level": "error",
+                    "project": {"slug": "my-app", "name": "My App"},
+                    "permalink": "https://sentry.io/org/my-app/issues/1"
+                }
+            }
+        }"#;
+        let events = source.process(payload).expect("sentry parse ok");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].severity, IssueSeverity::High);
+        assert!(events[0].title.contains("ZeroDivisionError"));
+        assert_eq!(events[0].source_type, IntakeSourceType::Sentry);
+    }
+
+    #[test]
+    fn test_sentry_intake_source_resolved_action_skipped() {
+        let source = SentryIntakeSource;
+        let payload = br#"{"action": "resolved", "data": {"issue": {"id": "1", "title": "Err", "level": "error"}}}"#;
+        let events = source.process(payload).expect("resolved parse ok");
+        assert!(events.is_empty());
     }
 }

--- a/examples/oris_operator_cli/Cargo.toml
+++ b/examples/oris_operator_cli/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1.0"
 tokio = { version = "1.36", features = ["rt-multi-thread", "macros"] }

--- a/examples/oris_operator_cli/src/main.rs
+++ b/examples/oris_operator_cli/src/main.rs
@@ -1,7 +1,19 @@
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde_json::{json, Value};
+
+#[derive(Debug, Clone, ValueEnum)]
+enum OutputFormat {
+    Json,
+    Table,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Json
+    }
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "oris-operator-cli")]
@@ -9,6 +21,12 @@ use serde_json::{json, Value};
 struct Cli {
     #[arg(long, default_value = "http://127.0.0.1:8080")]
     server: String,
+    /// Bearer token for API authentication (sets Authorization header).
+    #[arg(long, env = "ORIS_API_TOKEN")]
+    token: Option<String>,
+    /// Output format: json (default) or table.
+    #[arg(long, default_value = "json")]
+    format: OutputFormat,
     #[command(subcommand)]
     command: Command,
 }
@@ -21,6 +39,9 @@ enum Command {
         input: Option<String>,
         #[arg(long)]
         idempotency_key: Option<String>,
+        /// Optional dispatch priority (higher = dispatched sooner).
+        #[arg(long)]
+        priority: Option<i32>,
     },
     List {
         #[arg(long)]
@@ -50,6 +71,26 @@ enum Command {
         #[arg(long)]
         reason: Option<String>,
     },
+    /// Dead-letter queue operations.
+    Dlq {
+        #[command(subcommand)]
+        action: DlqCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum DlqCommand {
+    /// List dead-letter queue entries.
+    List {
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        #[arg(long, default_value_t = 0)]
+        offset: usize,
+    },
+    /// Inspect a single DLQ entry.
+    Inspect { attempt_id: String },
+    /// Replay a dead-letter attempt.
+    Replay { attempt_id: String },
 }
 
 #[tokio::main]
@@ -57,18 +98,25 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let client = Client::builder().build()?;
     let base = cli.server.trim_end_matches('/');
+    let token = cli.token.as_deref();
+    let format = &cli.format;
 
     let result = match cli.command {
         Command::Run {
             thread_id,
             input,
             idempotency_key,
+            priority,
         } => {
-            let req = client.post(format!("{}/v1/jobs/run", base)).json(&json!({
-                "thread_id": thread_id,
-                "input": input,
-                "idempotency_key": idempotency_key
-            }));
+            let req = auth(
+                client.post(format!("{}/v1/jobs/run", base)).json(&json!({
+                    "thread_id": thread_id,
+                    "input": input,
+                    "idempotency_key": idempotency_key,
+                    "priority": priority
+                })),
+                token,
+            );
             send_and_decode(req).await?
         }
         Command::List {
@@ -81,11 +129,11 @@ async fn main() -> Result<()> {
             if let Some(status) = status {
                 query.push(("status", status));
             }
-            let req = client.get(format!("{}/v1/jobs", base)).query(&query);
+            let req = auth(client.get(format!("{}/v1/jobs", base)).query(&query), token);
             send_and_decode(req).await?
         }
         Command::Inspect { thread_id } => {
-            let req = client.get(format!("{}/v1/jobs/{}", base, thread_id));
+            let req = auth(client.get(format!("{}/v1/jobs/{}", base, thread_id)), token);
             send_and_decode(req).await?
         }
         Command::Resume {
@@ -95,37 +143,107 @@ async fn main() -> Result<()> {
         } => {
             let parsed_value: Value =
                 serde_json::from_str(&value).context("`--value` must be valid JSON")?;
-            let req = client
-                .post(format!("{}/v1/jobs/{}/resume", base, thread_id))
-                .json(&json!({
-                    "value": parsed_value,
-                    "checkpoint_id": checkpoint_id
-                }));
+            let req = auth(
+                client
+                    .post(format!("{}/v1/jobs/{}/resume", base, thread_id))
+                    .json(&json!({
+                        "value": parsed_value,
+                        "checkpoint_id": checkpoint_id
+                    })),
+                token,
+            );
             send_and_decode(req).await?
         }
         Command::Replay {
             thread_id,
             checkpoint_id,
         } => {
-            let req = client
-                .post(format!("{}/v1/jobs/{}/replay", base, thread_id))
-                .json(&json!({
-                    "checkpoint_id": checkpoint_id
-                }));
+            let req = auth(
+                client
+                    .post(format!("{}/v1/jobs/{}/replay", base, thread_id))
+                    .json(&json!({
+                        "checkpoint_id": checkpoint_id
+                    })),
+                token,
+            );
             send_and_decode(req).await?
         }
         Command::Cancel { thread_id, reason } => {
-            let req = client
-                .post(format!("{}/v1/jobs/{}/cancel", base, thread_id))
-                .json(&json!({
-                    "reason": reason
-                }));
+            let req = auth(
+                client
+                    .post(format!("{}/v1/jobs/{}/cancel", base, thread_id))
+                    .json(&json!({ "reason": reason })),
+                token,
+            );
             send_and_decode(req).await?
         }
+        Command::Dlq { action } => match action {
+            DlqCommand::List { limit, offset } => {
+                let req = auth(
+                    client
+                        .get(format!("{}/v1/dlq", base))
+                        .query(&[("limit", limit.to_string()), ("offset", offset.to_string())]),
+                    token,
+                );
+                send_and_decode(req).await?
+            }
+            DlqCommand::Inspect { attempt_id } => {
+                let req = auth(client.get(format!("{}/v1/dlq/{}", base, attempt_id)), token);
+                send_and_decode(req).await?
+            }
+            DlqCommand::Replay { attempt_id } => {
+                let req = auth(
+                    client.post(format!("{}/v1/dlq/{}/replay", base, attempt_id)),
+                    token,
+                );
+                send_and_decode(req).await?
+            }
+        },
     };
 
-    println!("{}", serde_json::to_string_pretty(&result)?);
+    print_output(&result, format);
     Ok(())
+}
+
+fn auth(req: RequestBuilder, token: Option<&str>) -> RequestBuilder {
+    if let Some(t) = token {
+        req.header("Authorization", format!("Bearer {}", t))
+    } else {
+        req
+    }
+}
+
+fn print_output(value: &Value, format: &OutputFormat) {
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(value).unwrap()),
+        OutputFormat::Table => print_table(value),
+    }
+}
+
+fn print_table(value: &Value) {
+    match value {
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    println!();
+                }
+                print_table(item);
+            }
+        }
+        Value::Object(map) => {
+            let key_width = map.keys().map(|k| k.len()).max().unwrap_or(10) + 2;
+            for (k, v) in map {
+                let val = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Null => "(null)".to_string(),
+                    other => other.to_string(),
+                };
+                println!("{:<width$} {}", format!("{}:", k), val, width = key_width);
+            }
+        }
+        Value::String(s) => println!("{}", s),
+        other => println!("{}", other),
+    }
 }
 
 async fn send_and_decode(req: RequestBuilder) -> Result<Value> {


### PR DESCRIPTION
## Summary

Implements three Phase 1 roadmap items targeting production-readiness and developer experience.

### P1-02: PrometheusIntakeSource & SentryIntakeSource — replace `todo!()`

- `PrometheusIntakeSource::process()`: parses Alertmanager v4 webhook JSON; emits one `IntakeEvent` per **firing** alert; severity mapped from `labels.severity`
- `SentryIntakeSource::process()`: parses Sentry issue-alert webhooks (action: `created`/`triggered`); severity from Sentry level; skips `resolved`/`assigned`
- 4 new unit tests: firing alert parsing, empty alerts, Sentry created, Sentry resolved skip

### P1-03: PostgreSQL priority-ordered dispatch

- Migration v5: `ALTER TABLE runtime_attempts ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`
- Two supporting indexes for efficient priority ordering
- `list_dispatchable_attempts` now orders by `priority DESC, attempt_no ASC` (matching SQLite)
- `POSTGRES_RUNTIME_SCHEMA_VERSION` bumped to 5

### P1-06: Operator CLI production hardening

- `--token` / `ORIS_API_TOKEN` env: Bearer auth on all requests
- `--format json|table`: table mode for human-readable output
- `dlq list / dlq inspect / dlq replay` subcommands
- `run --priority <i32>` flag
- clap `env` feature enabled in Cargo.toml

## Validation
- `cargo fmt --all -- --check` passed
- `cargo test -p oris-intake --lib`: **36 passed**
- `cargo test -p oris-execution-runtime --features sqlite-persistence`: **44 passed**
- `cargo build --all --release --all-features`: **Finished** (0 errors)
