### PR TITLE
feat: Phase 1 P1-04/P1-05 - PostgreSQL idempotency store, worker health tracker, scheduler backpressure

### DIFF
--- a/crates/oris-execution-runtime/src/lease.rs
+++ b/crates/oris-execution-runtime/src/lease.rs
@@ -5,6 +5,9 @@
 //! running work. Lease expiry and recovery are handled by [LeaseManager::tick]
 //! (expire stale leases, requeue attempts); replay-restart is re-dispatch after requeue.
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 use chrono::{DateTime, Duration, Utc};
 
 use oris_kernel::event::KernelError;
@@ -123,6 +126,94 @@ impl<R: RuntimeRepository> LeaseManager for RepositoryLeaseManager<R> {
             timed_out,
             expired_requeued: expired,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorkerHealthTracker — per-worker lease-expiry counter
+// ---------------------------------------------------------------------------
+
+/// Per-worker health statistics maintained by the scheduler or control plane.
+#[derive(Clone, Debug, Default)]
+pub struct WorkerHealth {
+    /// Total number of times this worker's leases have been expired and requeued.
+    pub lease_expiry_count: u64,
+    /// Last time a heartbeat was observed from this worker (epoch ms).
+    pub last_heartbeat_ms: Option<i64>,
+    /// Whether this worker is currently quarantined (too many consecutive expirations).
+    pub quarantined: bool,
+}
+
+/// Thread-safe tracker that records per-worker health statistics.
+///
+/// When `lease_expiry_count` for a worker reaches `quarantine_threshold`, the
+/// worker is marked `quarantined = true`. A quarantined worker should not
+/// receive new dispatch leases until it is explicitly cleared.
+#[derive(Clone, Default)]
+pub struct WorkerHealthTracker {
+    inner: Arc<Mutex<HashMap<String, WorkerHealth>>>,
+    /// Number of consecutive lease expirations before a worker is quarantined.
+    /// Defaults to 5.
+    quarantine_threshold: u64,
+}
+
+impl WorkerHealthTracker {
+    pub fn new(quarantine_threshold: u64) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            quarantine_threshold,
+        }
+    }
+
+    /// Record one lease expiry for `worker_id`.
+    /// Returns `true` if the worker was just quarantined by this call.
+    pub fn record_expiry(&self, worker_id: &str) -> bool {
+        let mut map = self.inner.lock().expect("worker health lock poisoned");
+        let entry = map.entry(worker_id.to_string()).or_default();
+        entry.lease_expiry_count += 1;
+        if !entry.quarantined && entry.lease_expiry_count >= self.quarantine_threshold {
+            entry.quarantined = true;
+            return true;
+        }
+        false
+    }
+
+    /// Record a heartbeat for `worker_id` and clear quarantine if set.
+    pub fn record_heartbeat(&self, worker_id: &str, heartbeat_ms: i64) {
+        let mut map = self.inner.lock().expect("worker health lock poisoned");
+        let entry = map.entry(worker_id.to_string()).or_default();
+        entry.last_heartbeat_ms = Some(heartbeat_ms);
+        // A successful heartbeat resets the expiry counter and lifts quarantine.
+        entry.lease_expiry_count = 0;
+        entry.quarantined = false;
+    }
+
+    /// Returns `true` if the worker is currently quarantined.
+    pub fn is_quarantined(&self, worker_id: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("worker health lock poisoned")
+            .get(worker_id)
+            .map(|h| h.quarantined)
+            .unwrap_or(false)
+    }
+
+    /// Snapshot the health record for `worker_id`, or `None` if unknown.
+    pub fn get(&self, worker_id: &str) -> Option<WorkerHealth> {
+        self.inner
+            .lock()
+            .expect("worker health lock poisoned")
+            .get(worker_id)
+            .cloned()
+    }
+
+    /// Clear quarantine and reset expiry counter for `worker_id`.
+    pub fn clear_quarantine(&self, worker_id: &str) {
+        let mut map = self.inner.lock().expect("worker health lock poisoned");
+        if let Some(entry) = map.get_mut(worker_id) {
+            entry.quarantined = false;
+            entry.lease_expiry_count = 0;
+        }
     }
 }
 
@@ -413,5 +504,55 @@ mod tests {
             .expect("cutoff lock")
             .expect("cutoff recorded");
         assert_eq!(seen_cutoff, now - Duration::seconds(7));
+    }
+
+    // -----------------------------------------------------------------------
+    // WorkerHealthTracker tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn worker_health_tracker_quarantines_after_threshold() {
+        let tracker = WorkerHealthTracker::new(3);
+        assert!(!tracker.is_quarantined("w1"));
+
+        let just_quarantined = tracker.record_expiry("w1");
+        assert!(!just_quarantined); // 1 < 3
+        tracker.record_expiry("w1"); // 2 < 3
+        let just_quarantined = tracker.record_expiry("w1"); // 3 >= 3
+        assert!(just_quarantined);
+        assert!(tracker.is_quarantined("w1"));
+    }
+
+    #[test]
+    fn worker_health_tracker_heartbeat_clears_quarantine() {
+        let tracker = WorkerHealthTracker::new(2);
+        tracker.record_expiry("w1");
+        tracker.record_expiry("w1");
+        assert!(tracker.is_quarantined("w1"));
+
+        tracker.record_heartbeat("w1", 1_700_000_000_000);
+        assert!(!tracker.is_quarantined("w1"));
+
+        let health = tracker.get("w1").expect("health record exists");
+        assert_eq!(health.lease_expiry_count, 0);
+        assert_eq!(health.last_heartbeat_ms, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn worker_health_tracker_clear_quarantine_explicit() {
+        let tracker = WorkerHealthTracker::new(1);
+        tracker.record_expiry("w1");
+        assert!(tracker.is_quarantined("w1"));
+
+        tracker.clear_quarantine("w1");
+        assert!(!tracker.is_quarantined("w1"));
+        assert_eq!(tracker.get("w1").map(|h| h.lease_expiry_count), Some(0));
+    }
+
+    #[test]
+    fn worker_health_tracker_unknown_worker_not_quarantined() {
+        let tracker = WorkerHealthTracker::new(3);
+        assert!(!tracker.is_quarantined("unknown-worker"));
+        assert!(tracker.get("unknown-worker").is_none());
     }
 }

--- a/crates/oris-execution-runtime/src/lib.rs
+++ b/crates/oris-execution-runtime/src/lib.rs
@@ -52,14 +52,19 @@ pub use graph_bridge::{
     ExecutionCheckpointView, ExecutionGraphBridge, ExecutionGraphBridgeError,
     ExecutionGraphBridgeErrorKind, ExecutionInvokeView, ExecutionStateView,
 };
-pub use lease::{LeaseConfig, LeaseManager, LeaseTickResult, RepositoryLeaseManager, WorkerLease};
+pub use lease::{
+    LeaseConfig, LeaseManager, LeaseTickResult, RepositoryLeaseManager, WorkerHealth,
+    WorkerHealthTracker, WorkerLease,
+};
 pub use models::{
     AttemptDispatchRecord, AttemptExecutionStatus, InterruptRecord, LeaseRecord, RunRecord,
     RunRuntimeStatus,
 };
 pub use observability::{KernelObservability, RejectionReason};
 #[cfg(feature = "kernel-postgres")]
-pub use postgres_runtime_repository::PostgresRuntimeRepository;
+pub use postgres_runtime_repository::{
+    PostgresIdempotencyRecord, PostgresIdempotencyStore, PostgresRuntimeRepository,
+};
 pub use recovery::{CrashRecoveryPipeline, RecoveryContext, RecoveryStep};
 pub use repository::RuntimeRepository;
 pub use scheduler::{DispatchContext, SchedulerDecision, SkeletonScheduler};

--- a/crates/oris-execution-runtime/src/postgres_runtime_repository.rs
+++ b/crates/oris-execution-runtime/src/postgres_runtime_repository.rs
@@ -17,7 +17,7 @@ use super::models::{
 };
 use super::repository::RuntimeRepository;
 
-const POSTGRES_RUNTIME_SCHEMA_VERSION: i64 = 5;
+const POSTGRES_RUNTIME_SCHEMA_VERSION: i64 = 6;
 
 fn is_valid_schema_ident(schema: &str) -> bool {
     !schema.is_empty()
@@ -577,6 +577,48 @@ impl PostgresRuntimeRepository {
                     sqlx::query(&sql_record)
                         .bind(5_i32)
                         .bind("attempt_priority_dispatch_order")
+                        .bind(now)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+
+                // Migration v6: API idempotency store for PostgreSQL backends
+                if current_version < 6 {
+                    let sql_idempotency = format!(
+                        "CREATE TABLE IF NOT EXISTS \"{}\".execution_idempotency (
+                            idempotency_key TEXT PRIMARY KEY,
+                            operation TEXT NOT NULL,
+                            thread_id TEXT NOT NULL,
+                            payload_hash TEXT NOT NULL,
+                            response_json TEXT NOT NULL,
+                            created_at_ms BIGINT NOT NULL
+                        )",
+                        schema
+                    );
+                    let sql_idx_idempotency = format!(
+                        "CREATE INDEX IF NOT EXISTS idx_execution_idempotency_created
+                         ON \"{}\".execution_idempotency(created_at_ms)",
+                        schema
+                    );
+                    sqlx::query(&sql_idempotency)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    sqlx::query(&sql_idx_idempotency)
+                        .execute(&pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let now = dt_to_ms(Utc::now());
+                    let sql_record = format!(
+                        "INSERT INTO \"{}\".runtime_schema_migrations(version, name, applied_at_ms)
+                         VALUES ($1, $2, $3)
+                         ON CONFLICT(version) DO NOTHING",
+                        schema
+                    );
+                    sqlx::query(&sql_record)
+                        .bind(6_i32)
+                        .bind("api_idempotency_store")
                         .bind(now)
                         .execute(&pool)
                         .await
@@ -2572,6 +2614,123 @@ impl RuntimeRepository for PostgresRuntimeRepository {
             )));
         }
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PostgresIdempotencyStore — mirrors SqliteIdempotencyStore with Postgres pool
+// ---------------------------------------------------------------------------
+
+/// Record returned / stored by [`PostgresIdempotencyStore`].
+///
+/// Mirrors the fields of `api_idempotency::IdempotencyRecord` so that the
+/// Postgres implementation carries no dependency on the sqlite-persistence
+/// feature flag.
+#[derive(Clone, Debug)]
+pub struct PostgresIdempotencyRecord {
+    pub operation: String,
+    pub thread_id: String,
+    pub payload_hash: String,
+    pub response_json: String,
+}
+
+/// PostgreSQL-backed idempotency helper for the execution API.
+///
+/// Provides the same `get` / `put` interface as `SqliteIdempotencyStore` so that
+/// `ExecutionApiState` can use whichever backend is configured at start-up.
+#[derive(Clone)]
+pub struct PostgresIdempotencyStore {
+    pool: PgPool,
+    schema: String,
+    db_runtime: Option<Arc<tokio::runtime::Runtime>>,
+}
+
+impl PostgresIdempotencyStore {
+    /// Create a new store backed by an existing pool.
+    ///
+    /// The caller must ensure that `ensure_schema()` has already been run on the
+    /// associated `PostgresRuntimeRepository` (which creates the
+    /// `execution_idempotency` table in migration v6) before calling any method
+    /// on this store.
+    pub fn new(pool: PgPool, schema: impl Into<String>) -> Self {
+        Self {
+            pool,
+            schema: schema.into(),
+            db_runtime: new_db_runtime().ok(),
+        }
+    }
+
+    fn runtime(&self) -> Result<&tokio::runtime::Runtime, String> {
+        self.db_runtime
+            .as_deref()
+            .ok_or_else(|| "postgres idempotency runtime not available".to_string())
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<PostgresIdempotencyRecord>, String> {
+        let pool = self.pool.clone();
+        let schema = self.schema.clone();
+        let key = key.to_string();
+        let rt = self.runtime()?;
+        rt.block_on(async move {
+            let sql = format!(
+                "SELECT operation, thread_id, payload_hash, response_json
+                 FROM \"{}\".execution_idempotency
+                 WHERE idempotency_key = $1",
+                schema
+            );
+            let row: Option<(String, String, String, String)> = sqlx::query_as(&sql)
+                .bind(&key)
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| format!("postgres idempotency get failed: {}", e))?;
+            Ok(
+                row.map(|(operation, thread_id, payload_hash, response_json)| {
+                    PostgresIdempotencyRecord {
+                        operation,
+                        thread_id,
+                        payload_hash,
+                        response_json,
+                    }
+                }),
+            )
+        })
+    }
+
+    pub fn put(&self, key: &str, record: &PostgresIdempotencyRecord) -> Result<(), String> {
+        let pool = self.pool.clone();
+        let schema = self.schema.clone();
+        let key = key.to_string();
+        let operation = record.operation.clone();
+        let thread_id = record.thread_id.clone();
+        let payload_hash = record.payload_hash.clone();
+        let response_json = record.response_json.clone();
+        let now = dt_to_ms(Utc::now());
+        let rt = self.runtime()?;
+        rt.block_on(async move {
+            let sql = format!(
+                "INSERT INTO \"{}\".execution_idempotency
+                 (idempotency_key, operation, thread_id, payload_hash, response_json, created_at_ms)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 ON CONFLICT(idempotency_key) DO UPDATE SET
+                   operation = EXCLUDED.operation,
+                   thread_id = EXCLUDED.thread_id,
+                   payload_hash = EXCLUDED.payload_hash,
+                   response_json = EXCLUDED.response_json,
+                   created_at_ms = EXCLUDED.created_at_ms",
+                schema
+            );
+            sqlx::query(&sql)
+                .bind(&key)
+                .bind(&operation)
+                .bind(&thread_id)
+                .bind(&payload_hash)
+                .bind(&response_json)
+                .bind(now)
+                .execute(&pool)
+                .await
+                .map_err(|e| format!("postgres idempotency put failed: {}", e))?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/oris-execution-runtime/src/scheduler.rs
+++ b/crates/oris-execution-runtime/src/scheduler.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use oris_kernel::event::KernelError;
 
 use super::models::AttemptDispatchRecord;
+use super::observability::RejectionReason;
 use super::repository::RuntimeRepository;
 
 const DISPATCH_SCAN_LIMIT: usize = 16;
@@ -19,6 +20,11 @@ pub struct DispatchContext {
     pub plugin_requirements: Option<Vec<String>>,
     /// Worker capability tags the scheduler may match against.
     pub worker_capabilities: Option<Vec<String>>,
+    /// Maximum queue depth before backpressure is applied.
+    /// When the number of dispatchable candidates meets or exceeds this limit,
+    /// `dispatch_one_with_context` returns `SchedulerDecision::Backpressure`
+    /// instead of acquiring a new lease.
+    pub max_queue_depth: Option<usize>,
 }
 
 impl DispatchContext {
@@ -35,6 +41,11 @@ impl DispatchContext {
         self.priority = Some(priority);
         self
     }
+
+    pub fn with_max_queue_depth(mut self, limit: usize) -> Self {
+        self.max_queue_depth = Some(limit);
+        self
+    }
 }
 
 /// Scheduler dispatch decision.
@@ -43,6 +54,11 @@ pub enum SchedulerDecision {
     Dispatched {
         attempt_id: String,
         worker_id: String,
+    },
+    /// Backpressure applied: the queue depth has exceeded the configured limit.
+    Backpressure {
+        reason: RejectionReason,
+        queue_depth: usize,
     },
     Noop,
 }
@@ -65,6 +81,10 @@ impl<R: RuntimeRepository> SkeletonScheduler<R> {
     /// Dispatch one attempt to `worker_id` with optional context for tenant/priority/capability routing.
     /// Context is passed through for future filtering or sorting; current implementation
     /// uses the same candidate list as `dispatch_one`.
+    ///
+    /// If `context.max_queue_depth` is set and the number of dispatchable candidates is
+    /// greater than or equal to that limit, returns `SchedulerDecision::Backpressure`
+    /// without acquiring any lease.
     pub fn dispatch_one_with_context(
         &self,
         worker_id: &str,
@@ -74,10 +94,21 @@ impl<R: RuntimeRepository> SkeletonScheduler<R> {
         let candidates: Vec<AttemptDispatchRecord> = self
             .repository
             .list_dispatchable_attempts(now, DISPATCH_SCAN_LIMIT)?;
-        // Optional: apply context-based sort (e.g. by priority when available on attempts).
-        if context.as_ref().and_then(|c| c.priority).is_some() {
-            // Placeholder: could sort by attempt priority when AttemptDispatchRecord carries it.
+
+        // Backpressure gate: if queue depth meets or exceeds the limit, reject dispatch.
+        if let Some(limit) = context.and_then(|c| c.max_queue_depth) {
+            if candidates.len() >= limit {
+                return Ok(SchedulerDecision::Backpressure {
+                    reason: RejectionReason::capacity_limit(format!(
+                        "queue depth {} >= limit {}",
+                        candidates.len(),
+                        limit
+                    )),
+                    queue_depth: candidates.len(),
+                });
+            }
         }
+
         let lease_expires_at = now + chrono::Duration::seconds(30);
 
         for candidate in candidates {
@@ -364,7 +395,9 @@ mod tests {
                 assert_eq!(attempt_id, "attempt-b");
                 assert_eq!(worker_id, "worker-scheduler");
             }
-            SchedulerDecision::Noop => panic!("expected a dispatch"),
+            SchedulerDecision::Noop | SchedulerDecision::Backpressure { .. } => {
+                panic!("expected a dispatch")
+            }
         }
 
         let claimed = repo.claimed_attempts.lock().expect("claimed lock");
@@ -414,5 +447,49 @@ mod tests {
             .with_priority(5);
         assert_eq!(ctx.tenant_id.as_deref(), Some("tenant-1"));
         assert_eq!(ctx.priority, Some(5));
+    }
+
+    #[test]
+    fn dispatch_one_with_context_applies_backpressure_when_queue_exceeds_limit() {
+        // 3 queued attempts, limit = 2  → backpressure should fire
+        let repo = FakeRepository::new(
+            vec![
+                attempt("attempt-a", 1),
+                attempt("attempt-b", 2),
+                attempt("attempt-c", 3),
+            ],
+            &[],
+        );
+        let scheduler = SkeletonScheduler::new(repo);
+        let ctx = DispatchContext::new().with_max_queue_depth(2);
+
+        let decision = scheduler
+            .dispatch_one_with_context("worker-1", Some(&ctx))
+            .expect("should not error on backpressure");
+
+        match decision {
+            SchedulerDecision::Backpressure { queue_depth, .. } => {
+                assert_eq!(queue_depth, 3);
+            }
+            other => panic!("expected Backpressure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dispatch_one_with_context_dispatches_when_queue_below_limit() {
+        // 1 queued attempt, limit = 5 → should dispatch normally
+        let repo = FakeRepository::new(vec![attempt("attempt-a", 1)], &[]);
+        let scheduler = SkeletonScheduler::new(repo);
+        let ctx = DispatchContext::new().with_max_queue_depth(5);
+
+        let decision = scheduler
+            .dispatch_one_with_context("worker-1", Some(&ctx))
+            .expect("dispatch should succeed");
+
+        assert!(
+            matches!(decision, SchedulerDecision::Dispatched { .. }),
+            "expected Dispatched, got {:?}",
+            decision
+        );
     }
 }

--- a/crates/oris-runtime/src/execution_server/api_handlers.rs
+++ b/crates/oris-runtime/src/execution_server/api_handlers.rs
@@ -2824,6 +2824,8 @@ pub struct ExecutionApiState {
     pub idempotency_store: Option<SqliteIdempotencyStore>,
     #[cfg(feature = "sqlite-persistence")]
     pub runtime_repo: Option<SqliteRuntimeRepository>,
+    #[cfg(feature = "kernel-postgres")]
+    pub pg_idempotency_store: Option<crate::execution_runtime::PostgresIdempotencyStore>,
     pub runtime_metrics: RuntimeMetrics,
     pub worker_poll_limit: usize,
     pub max_active_leases_per_worker: usize,
@@ -2958,6 +2960,8 @@ impl ExecutionApiState {
             idempotency_store: None,
             #[cfg(feature = "sqlite-persistence")]
             runtime_repo: None,
+            #[cfg(feature = "kernel-postgres")]
+            pg_idempotency_store: None,
             runtime_metrics: RuntimeMetrics::default(),
             worker_poll_limit: 1,
             max_active_leases_per_worker: 8,
@@ -8386,6 +8390,46 @@ pub async fn run_job(
         }
     }
 
+    #[cfg(feature = "kernel-postgres")]
+    if let (Some(key), Some(store)) = (
+        req.idempotency_key.clone(),
+        state.pg_idempotency_store.as_ref(),
+    ) {
+        if key.trim().is_empty() {
+            return Err(ApiError::bad_request("idempotency_key must not be empty")
+                .with_request_id(rid.clone()));
+        }
+        if let Some(existing) = store
+            .get(&key)
+            .map_err(|e| ApiError::internal(e).with_request_id(rid.clone()))?
+        {
+            if existing.operation == "run"
+                && existing.thread_id == req.thread_id
+                && existing.payload_hash == request_payload_hash
+            {
+                let mut response: RunJobResponse = serde_json::from_str(&existing.response_json)
+                    .map_err(|e| {
+                        ApiError::internal(format!("decode idempotent response failed: {}", e))
+                            .with_request_id(rid.clone())
+                    })?;
+                response.idempotent_replay = true;
+                return Ok(Json(ApiEnvelope {
+                    meta: ApiMeta::ok(),
+                    request_id: rid,
+                    data: response,
+                }));
+            }
+            return Err(ApiError::conflict(
+                "idempotency_key already exists with different request payload",
+            )
+            .with_request_id(rid.clone())
+            .with_details(serde_json::json!({
+                "idempotency_key": key,
+                "operation": existing.operation
+            })));
+        }
+    }
+
     record_task_queued(
         &state,
         &req.thread_id,
@@ -8505,6 +8549,25 @@ pub async fn run_job(
         state.idempotency_store.as_ref(),
     ) {
         let record = IdempotencyRecord {
+            operation: "run".to_string(),
+            thread_id: req.thread_id.clone(),
+            payload_hash: request_payload_hash.clone(),
+            response_json: serde_json::to_string(&response).map_err(|e| {
+                ApiError::internal(format!("encode idempotent response failed: {}", e))
+                    .with_request_id(rid.clone())
+            })?,
+        };
+        store
+            .put(&key, &record)
+            .map_err(|e| ApiError::internal(e).with_request_id(rid.clone()))?;
+    }
+
+    #[cfg(feature = "kernel-postgres")]
+    if let (Some(key), Some(store)) = (
+        req.idempotency_key.clone(),
+        state.pg_idempotency_store.as_ref(),
+    ) {
+        let record = crate::execution_runtime::PostgresIdempotencyRecord {
             operation: "run".to_string(),
             thread_id: req.thread_id.clone(),
             payload_hash: request_payload_hash,

--- a/crates/oris-runtime/src/execution_server/benchmark_suite.rs
+++ b/crates/oris-runtime/src/execution_server/benchmark_suite.rs
@@ -192,6 +192,13 @@ fn bench_dispatch_path(
             SchedulerDecision::Noop => {
                 return Err("dispatch benchmark unexpectedly produced noop".into());
             }
+            SchedulerDecision::Backpressure { queue_depth, .. } => {
+                return Err(format!(
+                    "dispatch benchmark unexpectedly hit backpressure (queue_depth={})",
+                    queue_depth
+                )
+                .into());
+            }
         }
 
         let outcome = repo.ack_attempt(


### PR DESCRIPTION
## Summary

Completes Phase 1 production-readiness with two items: PostgreSQL idempotency store parity and worker health/backpressure infrastructure.

### P1-05: PostgreSQL idempotency store

- **Migration v6** in `postgres_runtime_repository.rs`: creates `execution_idempotency` table with `idempotency_key` PK and index on `created_at_ms`
- `PostgresIdempotencyRecord` + `PostgresIdempotencyStore` (fully self-contained, no cross-feature dependencies)
- `ExecutionApiState.pg_idempotency_store: Option<PostgresIdempotencyStore>` gated on `#[cfg(feature = "kernel-postgres")]`
- `run_job`: idempotency check (get + conflict 409) and store (put) wired for the Postgres path
- `POSTGRES_RUNTIME_SCHEMA_VERSION` bumped to **6**

### P1-04: Worker health tracking and scheduler backpressure

- `WorkerHealthTracker`: thread-safe per-worker lease-expiry counter; auto-quarantines after `N` consecutive expirations; clears on heartbeat
- `WorkerHealth`: public `{ lease_expiry_count, last_heartbeat_ms, quarantined }` snapshot
- `SchedulerDecision::Backpressure { reason: RejectionReason, queue_depth: usize }` new variant
- `DispatchContext::max_queue_depth`: when `candidates.len() >= limit`, dispatch returns `Backpressure` without acquiring any lease
- `benchmark_suite.rs` updated for exhaustive match

## Validation
- `cargo fmt --all -- --check` passed
- `cargo test -p oris-execution-runtime --features sqlite-persistence`: **50 passed** (6 new tests)
- `cargo build --all --release --all-features`: **Finished** (0 errors)
