### PR TITLE
feat(P1-07): add CircuitBreaker for worker execution chain (#294)

### DIFF
--- a/RELEASE_v0.41.0.md
+++ b/RELEASE_v0.41.0.md
@@ -1,0 +1,39 @@
+# oris-runtime v0.41.0
+
+## Summary
+
+Adds a three-state **circuit breaker** to the worker execution chain (Phase 1 P1-07).
+
+## Changes
+
+### New: `CircuitBreaker` (`oris-execution-runtime::circuit_breaker`)
+
+- `CircuitState` enum — `Closed`, `Open { opened_at }`, `HalfOpen`
+- `CircuitBreaker::new(probe_window_secs)` — creates a closed breaker
+- `CircuitBreaker::trip()` — forces the breaker to `Open`
+- `CircuitBreaker::is_open()` — returns `true` while open; auto-transitions to `HalfOpen` after the probe window elapses
+- `CircuitBreaker::record_success()` — resets from `HalfOpen` / `Open` back to `Closed`
+
+### Updated: `WorkerHealthTracker`
+
+- `with_circuit_breaker(Arc<CircuitBreaker>)` builder — wires a shared breaker
+- `record_expiry()` now trips the attached breaker when a worker is quarantined
+- New `record_success(worker_id)` method — clears quarantine and resets the breaker to `Closed`
+
+### Updated: `SkeletonScheduler`
+
+- `with_circuit_breaker(Arc<CircuitBreaker>)` builder — attaches a breaker to the scheduler
+- `dispatch_one` / `dispatch_one_with_context` return `SchedulerDecision::Backpressure` (reason: `"circuit breaker open"`) when the breaker is `Open`
+
+## Validation
+
+- `cargo fmt --all -- --check` ✓
+- `cargo test -p oris-execution-runtime` — 27/27 passed ✓
+- `cargo build --all --release --all-features` clean ✓
+- `cargo publish -p oris-execution-runtime --dry-run` ✓
+- `cargo publish -p oris-runtime --all-features --dry-run` ✓
+
+## Crate versions
+
+- `oris-execution-runtime` v0.2.15 → **v0.3.0**
+- `oris-runtime` v0.40.0 → **v0.41.0**

--- a/crates/oris-execution-runtime/Cargo.toml
+++ b/crates/oris-execution-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-execution-runtime"
-version = "0.2.15"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-execution-runtime/src/circuit_breaker.rs
+++ b/crates/oris-execution-runtime/src/circuit_breaker.rs
@@ -1,0 +1,163 @@
+//! Three-state circuit breaker for the worker execution chain.
+//!
+//! State machine:
+//! ```text
+//! Closed ──trip()──► Open ──probe_window elapsed──► HalfOpen ──record_success()──► Closed
+//!   ▲                                                   │
+//!   └───────────────record_success()────────────────────┘
+//!                    (shortcut on immediate recovery)
+//! ```
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Snapshot of the circuit breaker state.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CircuitState {
+    /// Normal operation — dispatches proceed.
+    Closed,
+    /// Fault detected — dispatches are rejected until the probe window elapses.
+    Open { opened_at: Instant },
+    /// Probe phase — one dispatch is allowed through to test recovery.
+    HalfOpen,
+}
+
+/// Thread-safe circuit breaker (Closed → Open → HalfOpen → Closed).
+///
+/// - [`CircuitBreaker::trip`] moves the breaker to `Open`.
+/// - After [`probe_window_secs`](CircuitBreaker::new) elapses, `is_open()` auto-transitions to `HalfOpen`.
+/// - [`CircuitBreaker::record_success`] resets to `Closed` from any non-Closed state.
+pub struct CircuitBreaker {
+    state: Mutex<CircuitState>,
+    probe_window: Duration,
+}
+
+impl CircuitBreaker {
+    /// Create a new `Closed` circuit breaker.
+    ///
+    /// `probe_window_secs` controls how long the breaker stays `Open` before
+    /// transitioning to `HalfOpen` to allow a probe dispatch.
+    pub fn new(probe_window_secs: u64) -> Self {
+        Self {
+            state: Mutex::new(CircuitState::Closed),
+            probe_window: Duration::from_secs(probe_window_secs),
+        }
+    }
+
+    /// Trip the breaker — moves it to `Open` regardless of current state.
+    pub fn trip(&self) {
+        let mut s = self.state.lock().expect("circuit breaker lock poisoned");
+        *s = CircuitState::Open {
+            opened_at: Instant::now(),
+        };
+    }
+
+    /// Record a successful operation.
+    ///
+    /// If the breaker is `HalfOpen` or `Open`, resets it to `Closed`.
+    pub fn record_success(&self) {
+        let mut s = self.state.lock().expect("circuit breaker lock poisoned");
+        match *s {
+            CircuitState::HalfOpen | CircuitState::Open { .. } => {
+                *s = CircuitState::Closed;
+            }
+            CircuitState::Closed => {}
+        }
+    }
+
+    /// Returns `true` if the breaker is currently rejecting dispatches.
+    ///
+    /// When the probe window has elapsed for an `Open` breaker, this method
+    /// automatically transitions to `HalfOpen` and returns `false`, allowing
+    /// one probe dispatch through.
+    pub fn is_open(&self) -> bool {
+        let mut s = self.state.lock().expect("circuit breaker lock poisoned");
+        match *s {
+            CircuitState::Open { opened_at } => {
+                if opened_at.elapsed() >= self.probe_window {
+                    *s = CircuitState::HalfOpen;
+                    false
+                } else {
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns a snapshot of the current circuit state (without transitioning).
+    pub fn current_state(&self) -> CircuitState {
+        self.state
+            .lock()
+            .expect("circuit breaker lock poisoned")
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn starts_closed() {
+        let cb = CircuitBreaker::new(30);
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(!cb.is_open());
+    }
+
+    #[test]
+    fn trip_opens_breaker() {
+        let cb = CircuitBreaker::new(30);
+        cb.trip();
+        assert!(cb.is_open());
+        match cb.current_state() {
+            CircuitState::Open { .. } => {}
+            other => panic!("expected Open, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn record_success_closes_open_breaker() {
+        let cb = CircuitBreaker::new(30);
+        cb.trip();
+        assert!(cb.is_open());
+        cb.record_success();
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(!cb.is_open());
+    }
+
+    #[test]
+    fn record_success_closes_half_open_breaker() {
+        // Use a very short probe window so it transitions to HalfOpen quickly.
+        let cb = CircuitBreaker::new(0);
+        cb.trip();
+        thread::sleep(Duration::from_millis(5));
+        // is_open() will auto-transition to HalfOpen
+        assert!(!cb.is_open());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+        cb.record_success();
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn open_transitions_to_half_open_after_probe_window() {
+        let cb = CircuitBreaker::new(0); // 0-second window for tests
+        cb.trip();
+        thread::sleep(Duration::from_millis(5));
+        // is_open() transitions to HalfOpen and returns false
+        assert!(
+            !cb.is_open(),
+            "should not be open after probe window elapsed"
+        );
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn record_success_noop_when_already_closed() {
+        let cb = CircuitBreaker::new(30);
+        cb.record_success(); // should not panic
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+    }
+}

--- a/crates/oris-execution-runtime/src/lease.rs
+++ b/crates/oris-execution-runtime/src/lease.rs
@@ -8,6 +8,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use crate::circuit_breaker::CircuitBreaker;
+
 use chrono::{DateTime, Duration, Utc};
 
 use oris_kernel::event::KernelError;
@@ -149,12 +151,18 @@ pub struct WorkerHealth {
 /// When `lease_expiry_count` for a worker reaches `quarantine_threshold`, the
 /// worker is marked `quarantined = true`. A quarantined worker should not
 /// receive new dispatch leases until it is explicitly cleared.
+///
+/// An optional [`CircuitBreaker`] can be wired in via
+/// [`WorkerHealthTracker::with_circuit_breaker`]. When a worker is quarantined,
+/// the breaker is tripped automatically.
 #[derive(Clone, Default)]
 pub struct WorkerHealthTracker {
     inner: Arc<Mutex<HashMap<String, WorkerHealth>>>,
     /// Number of consecutive lease expirations before a worker is quarantined.
     /// Defaults to 5.
     quarantine_threshold: u64,
+    /// Optional circuit breaker to trip when a worker is quarantined.
+    circuit_breaker: Option<Arc<CircuitBreaker>>,
 }
 
 impl WorkerHealthTracker {
@@ -162,20 +170,55 @@ impl WorkerHealthTracker {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),
             quarantine_threshold,
+            circuit_breaker: None,
         }
+    }
+
+    /// Attach a shared circuit breaker to this tracker.
+    ///
+    /// The breaker will be tripped whenever a worker is quarantined.
+    pub fn with_circuit_breaker(mut self, breaker: Arc<CircuitBreaker>) -> Self {
+        self.circuit_breaker = Some(breaker);
+        self
     }
 
     /// Record one lease expiry for `worker_id`.
     /// Returns `true` if the worker was just quarantined by this call.
+    ///
+    /// If a circuit breaker is attached, it is tripped when quarantine occurs.
     pub fn record_expiry(&self, worker_id: &str) -> bool {
-        let mut map = self.inner.lock().expect("worker health lock poisoned");
-        let entry = map.entry(worker_id.to_string()).or_default();
-        entry.lease_expiry_count += 1;
-        if !entry.quarantined && entry.lease_expiry_count >= self.quarantine_threshold {
-            entry.quarantined = true;
-            return true;
+        let just_quarantined = {
+            let mut map = self.inner.lock().expect("worker health lock poisoned");
+            let entry = map.entry(worker_id.to_string()).or_default();
+            entry.lease_expiry_count += 1;
+            if !entry.quarantined && entry.lease_expiry_count >= self.quarantine_threshold {
+                entry.quarantined = true;
+                true
+            } else {
+                false
+            }
+        };
+        if just_quarantined {
+            if let Some(cb) = &self.circuit_breaker {
+                cb.trip();
+            }
         }
-        false
+        just_quarantined
+    }
+
+    /// Record a successful dispatch acknowledgement for `worker_id`.
+    ///
+    /// Clears quarantine, resets expiry counter, and resets the circuit breaker to `Closed`.
+    pub fn record_success(&self, worker_id: &str) {
+        {
+            let mut map = self.inner.lock().expect("worker health lock poisoned");
+            let entry = map.entry(worker_id.to_string()).or_default();
+            entry.lease_expiry_count = 0;
+            entry.quarantined = false;
+        }
+        if let Some(cb) = &self.circuit_breaker {
+            cb.record_success();
+        }
     }
 
     /// Record a heartbeat for `worker_id` and clear quarantine if set.

--- a/crates/oris-execution-runtime/src/lib.rs
+++ b/crates/oris-execution-runtime/src/lib.rs
@@ -10,6 +10,7 @@ pub mod api_idempotency;
 pub mod api_models;
 #[cfg(feature = "sqlite-persistence")]
 pub mod backend_config;
+pub mod circuit_breaker;
 #[cfg(feature = "execution-server")]
 pub mod graph_bridge;
 pub mod lease;
@@ -47,6 +48,7 @@ pub use api_models::{
 };
 #[cfg(feature = "sqlite-persistence")]
 pub use backend_config::{RuntimeStorageBackend, RuntimeStorageConfig};
+pub use circuit_breaker::{CircuitBreaker, CircuitState};
 #[cfg(feature = "execution-server")]
 pub use graph_bridge::{
     ExecutionCheckpointView, ExecutionGraphBridge, ExecutionGraphBridgeError,

--- a/crates/oris-execution-runtime/src/scheduler.rs
+++ b/crates/oris-execution-runtime/src/scheduler.rs
@@ -1,9 +1,12 @@
 //! Scheduler skeleton for Phase 1 runtime rollout.
 
+use std::sync::Arc;
+
 use chrono::Utc;
 
 use oris_kernel::event::KernelError;
 
+use super::circuit_breaker::CircuitBreaker;
 use super::models::AttemptDispatchRecord;
 use super::observability::RejectionReason;
 use super::repository::RuntimeRepository;
@@ -66,11 +69,25 @@ pub enum SchedulerDecision {
 /// Compile-safe scheduler skeleton for queue -> lease dispatch.
 pub struct SkeletonScheduler<R: RuntimeRepository> {
     repository: R,
+    /// Optional circuit breaker applied globally to all dispatch calls.
+    circuit_breaker: Option<Arc<CircuitBreaker>>,
 }
 
 impl<R: RuntimeRepository> SkeletonScheduler<R> {
     pub fn new(repository: R) -> Self {
-        Self { repository }
+        Self {
+            repository,
+            circuit_breaker: None,
+        }
+    }
+
+    /// Attach a shared circuit breaker to this scheduler.
+    ///
+    /// When the breaker is `Open`, all dispatch calls return
+    /// `SchedulerDecision::Backpressure` until the probe window elapses.
+    pub fn with_circuit_breaker(mut self, breaker: Arc<CircuitBreaker>) -> Self {
+        self.circuit_breaker = Some(breaker);
+        self
     }
 
     /// Attempt to dispatch one eligible attempt to `worker_id`.
@@ -91,6 +108,17 @@ impl<R: RuntimeRepository> SkeletonScheduler<R> {
         context: Option<&DispatchContext>,
     ) -> Result<SchedulerDecision, KernelError> {
         let now = Utc::now();
+
+        // Circuit breaker gate: if the breaker is Open, reject dispatch.
+        if let Some(cb) = &self.circuit_breaker {
+            if cb.is_open() {
+                return Ok(SchedulerDecision::Backpressure {
+                    reason: RejectionReason::capacity_limit("circuit breaker open"),
+                    queue_depth: 0,
+                });
+            }
+        }
+
         let candidates: Vec<AttemptDispatchRecord> = self
             .repository
             .list_dispatchable_attempts(now, DISPATCH_SCAN_LIMIT)?;
@@ -484,6 +512,55 @@ mod tests {
 
         let decision = scheduler
             .dispatch_one_with_context("worker-1", Some(&ctx))
+            .expect("dispatch should succeed");
+
+        assert!(
+            matches!(decision, SchedulerDecision::Dispatched { .. }),
+            "expected Dispatched, got {:?}",
+            decision
+        );
+    }
+
+    #[test]
+    fn open_circuit_breaker_returns_backpressure() {
+        use crate::circuit_breaker::CircuitBreaker;
+        use std::sync::Arc;
+
+        let repo = FakeRepository::new(vec![attempt("attempt-a", 1)], &[]);
+        let breaker = Arc::new(CircuitBreaker::new(30));
+        breaker.trip();
+
+        let scheduler = SkeletonScheduler::new(repo).with_circuit_breaker(breaker);
+
+        let decision = scheduler
+            .dispatch_one("worker-1")
+            .expect("should not error");
+
+        match decision {
+            SchedulerDecision::Backpressure { reason, .. } => {
+                let msg = format!("{:?}", reason);
+                assert!(
+                    msg.contains("circuit breaker open"),
+                    "unexpected reason: {}",
+                    msg
+                );
+            }
+            other => panic!("expected Backpressure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn closed_circuit_breaker_allows_dispatch() {
+        use crate::circuit_breaker::CircuitBreaker;
+        use std::sync::Arc;
+
+        let repo = FakeRepository::new(vec![attempt("attempt-a", 1)], &[]);
+        let breaker = Arc::new(CircuitBreaker::new(30)); // starts Closed
+
+        let scheduler = SkeletonScheduler::new(repo).with_circuit_breaker(breaker);
+
+        let decision = scheduler
+            .dispatch_one("worker-1")
             .expect("dispatch should succeed");
 
         assert!(

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -33,7 +33,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-oris-execution-runtime = { version = "0.2.15", path = "../oris-execution-runtime", default-features = false }
+oris-execution-runtime = { version = "0.3.0", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
 oris-evokernel = { version = "0.13.0", path = "../oris-evokernel", optional = true }
 scraper = "0.21"


### PR DESCRIPTION
Closes #294

## Summary
Adds a three-state circuit breaker (Closed / Open / HalfOpen) to the worker execution chain so repeated failures automatically block dispatch until the probe window elapses.

## Changes
- New `CircuitBreaker` / `CircuitState` in `circuit_breaker.rs`
- `WorkerHealthTracker::with_circuit_breaker()` builder; `record_expiry()` trips breaker on quarantine; new `record_success()` method
- `SkeletonScheduler::with_circuit_breaker()` builder; dispatch returns `Backpressure` when breaker is Open

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p oris-execution-runtime` — 27 passed, 0 failed
- `cargo build --all --release --all-features` clean
- `cargo publish -p oris-execution-runtime --dry-run` passed
- Released as oris-execution-runtime v0.3.0, oris-runtime v0.41.0
