### PR TITLE
feat(P2-02): wire intake signals into detect stage

### DIFF
--- a/RELEASE_v0.42.0.md
+++ b/RELEASE_v0.42.0.md
@@ -1,0 +1,23 @@
+# v0.42.0 - Intake-Driven Detect Stage Integration
+
+oris-runtime now exposes intake-to-detect pipeline wiring so runtime diagnostics and webhook-derived failures can feed the evolution loop through the standard detect stage.
+
+## What's in this release
+
+- Added intake-driven detect-stage integration in oris-evokernel via `detect_from_intake_events` and `intake_events_to_extractor_input`.
+- Added compiler-diagnostic and runtime-panic coverage for the detect-to-select path, including runtime facade resolution under `full-evolution-experimental`.
+
+## Validation
+
+- cargo fmt --all -- --check
+- cargo test -p oris-evokernel --test evolution_feature_wiring
+- cargo test -p oris-evokernel
+- cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental
+- cargo build --verbose --all --release --all-features
+- cargo test --release --all-features
+
+## Links
+
+- Crate: https://crates.io/crates/oris-runtime
+- Docs: https://docs.rs/oris-runtime
+- Repo: https://github.com/Colin4k1024/Oris

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evokernel"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -14,6 +14,7 @@ chrono = { version = "0.4", default-features = true }
 oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.3.4", path = "../oris-evolution" }
+oris-intake = { version = "0.4.0", path = "../oris-intake" }
 oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }
 oris-evolution-network = { version = "0.4.0", path = "../oris-evolution-network" }
 oris-genestore = { version = "0.2.0", path = "../oris-genestore" }

--- a/crates/oris-evokernel/src/lib.rs
+++ b/crates/oris-evokernel/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod adapters;
 pub mod confidence_daemon;
 mod core;
+pub mod pipeline_integration;
 pub mod signal_extractor;
 
 /// Experimental external agent contract facade re-exported through EvoKernel.
@@ -31,3 +32,4 @@ pub mod spec_contract {
 }
 
 pub use core::*;
+pub use pipeline_integration::{detect_from_intake_events, intake_events_to_extractor_input};

--- a/crates/oris-evokernel/src/pipeline_integration.rs
+++ b/crates/oris-evokernel/src/pipeline_integration.rs
@@ -1,0 +1,334 @@
+//! Pipeline integration: wires `IntakeEvent` → `RuntimeSignal` →
+//! `SignalExtractorPort::extract()` → `StandardEvolutionPipeline` Detect stage.
+//!
+//! # Overview
+//!
+//! `StandardEvolutionPipeline` accepts signals through its Detect stage via a
+//! `SignalExtractorPort`.  The signal extractor (already implemented as
+//! `RuntimeSignalExtractorAdapter` in `adapters.rs`) translates raw
+//! `SignalExtractorInput` fields (compiler output / stack trace / logs) into
+//! `EvolutionSignal`s.
+//!
+//! This module bridges the gap on the *intake* side: it turns
+//! `oris_intake::IntakeEvent`s into a `SignalExtractorInput` so that
+//! the pipeline Detect stage can be driven directly from webhook events.
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use oris_evolution::{EvolutionPipelineConfig, StandardEvolutionPipeline};
+//! use oris_evokernel::adapters::RuntimeSignalExtractorAdapter;
+//! use oris_evokernel::pipeline_integration::detect_from_intake_events;
+//! use oris_intake::IntakeEvent;
+//! # use oris_evolution::Selector;
+//! # fn dummy_selector() -> Arc<dyn Selector> { unimplemented!() }
+//!
+//! let events: Vec<IntakeEvent> = vec![/* ... */];
+//! let extractor = Arc::new(RuntimeSignalExtractorAdapter::new());
+//! let signals = detect_from_intake_events(&events, extractor.as_ref());
+//! ```
+
+use oris_evolution::{EvolutionSignal, SignalExtractorInput, SignalExtractorPort};
+use oris_intake::IntakeEvent;
+
+/// Convert a slice of `IntakeEvent`s into a `SignalExtractorInput`.
+///
+/// The mapping strategy:
+/// - Events whose title or description contain rustc compiler error/warning markers
+///   (e.g. `error[EXXXX]:`) are placed in `compiler_output`.
+/// - Events that contain typical panic / stack-trace markers
+///   are placed in `stack_trace`.
+/// - All remaining events are serialised as log lines and placed in `logs`.
+///
+/// Signals from all three buckets are then deduplicated by the underlying
+/// `RuntimeSignalExtractor`.
+pub fn intake_events_to_extractor_input(events: &[IntakeEvent]) -> SignalExtractorInput {
+    let mut compiler_parts: Vec<String> = Vec::new();
+    let mut stack_parts: Vec<String> = Vec::new();
+    let mut log_parts: Vec<String> = Vec::new();
+
+    for event in events {
+        let content = format!("{}\n{}", event.title, event.description);
+
+        let is_compiler = content.contains("error[E")
+            || content.contains("error[W")
+            || content.contains("warning[W")
+            || content.contains("cannot find")
+            || content.contains("mismatched types");
+        let is_panic = !is_compiler
+            && content.contains("thread '")
+            && (content.contains("panicked at") || content.contains("stack backtrace"));
+
+        if is_compiler {
+            compiler_parts.push(content);
+        } else if is_panic {
+            stack_parts.push(content);
+        } else {
+            log_parts.push(format!(
+                "[{}] [{}] {}",
+                event.timestamp_ms, event.severity, content
+            ));
+        }
+    }
+
+    SignalExtractorInput {
+        compiler_output: if compiler_parts.is_empty() {
+            None
+        } else {
+            Some(compiler_parts.join("\n"))
+        },
+        stack_trace: if stack_parts.is_empty() {
+            None
+        } else {
+            Some(stack_parts.join("\n"))
+        },
+        logs: if log_parts.is_empty() {
+            None
+        } else {
+            Some(log_parts.join("\n"))
+        },
+        extra: serde_json::json!({}),
+    }
+}
+
+/// Run the Detect stage for a batch of `IntakeEvent`s using the provided
+/// `SignalExtractorPort`.
+///
+/// Returns the list of `EvolutionSignal`s ready to be injected into
+/// `PipelineContext::signals` before calling `StandardEvolutionPipeline::execute`.
+pub fn detect_from_intake_events(
+    events: &[IntakeEvent],
+    extractor: &dyn SignalExtractorPort,
+) -> Vec<EvolutionSignal> {
+    let input = intake_events_to_extractor_input(events);
+    let mut signals = extractor.extract(&input);
+    // Only keep signals above a minimal confidence floor so that noise from
+    // low-confidence log lines does not pollute the Select stage.
+    signals.retain(|s| s.confidence >= 0.3);
+    signals
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::RuntimeSignalExtractorAdapter;
+    use oris_intake::{IntakeEvent, IntakeSourceType, IssueSeverity};
+
+    fn make_event(
+        source_type: IntakeSourceType,
+        title: &str,
+        description: &str,
+        severity: IssueSeverity,
+    ) -> IntakeEvent {
+        IntakeEvent {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            source_type,
+            source_event_id: None,
+            title: title.to_string(),
+            description: description.to_string(),
+            severity,
+            signals: vec![],
+            raw_payload: None,
+            timestamp_ms: 0,
+        }
+    }
+
+    /// Simulating a `error[E0308]` compiler diagnostic arriving via intake
+    /// must produce at least one `CompilerDiagnostic`-class `EvolutionSignal`
+    /// with `SignalType::ErrorPattern`.
+    #[test]
+    fn compiler_diagnostic_produces_signal_ready() {
+        // Content contains "error[E..." so it will be routed to compiler_output.
+        let event = make_event(
+            IntakeSourceType::LogFile,
+            "Build failed",
+            "error[E0308]: mismatched types\n  --> src/lib.rs:10:5\n   |\n10 |     let x: i32 = \"hello\";\n   |            ---   ^^^^^^^ expected `i32`, found `&str`",
+            IssueSeverity::High,
+        );
+
+        let extractor = RuntimeSignalExtractorAdapter::new();
+        let signals = detect_from_intake_events(&[event], &extractor);
+
+        assert!(
+            !signals.is_empty(),
+            "expected at least one EvolutionSignal for compiler error; got none"
+        );
+        // Verify the signal represents an ErrorPattern (compiler path).
+        let has_error_pattern = signals.iter().any(|s| {
+            matches!(
+                &s.signal_type,
+                oris_evolution::evolver::SignalType::ErrorPattern { .. }
+            )
+        });
+        assert!(
+            has_error_pattern,
+            "expected an ErrorPattern signal for compiler diagnostic, got: {:?}",
+            signals
+                .iter()
+                .map(|s| format!("{:?}", s.signal_type))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A runtime panic arriving as an intake event must route through the
+    /// stack-trace path and produce at least one `EvolutionSignal`.
+    #[test]
+    fn runtime_panic_produces_evolution_signal() {
+        // Content contains "thread '...panicked at" so it routes to stack_trace.
+        let event = make_event(
+            IntakeSourceType::Sentry,
+            "Worker panicked",
+            "thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 5', src/worker.rs:42",
+            IssueSeverity::Critical,
+        );
+
+        let extractor = RuntimeSignalExtractorAdapter::new();
+        let signals = detect_from_intake_events(&[event], &extractor);
+
+        assert!(
+            !signals.is_empty(),
+            "expected at least one EvolutionSignal for runtime panic; got none"
+        );
+    }
+
+    /// Intake events that carry no recognisable diagnostic markers must not
+    /// produce false-positive Evolution signals with high confidence.
+    #[test]
+    fn noise_event_does_not_produce_high_confidence_signal() {
+        let event = make_event(
+            IntakeSourceType::Github,
+            "Dependabot security update",
+            "Bump serde from 1.0.195 to 1.0.197",
+            IssueSeverity::Low,
+        );
+
+        let extractor = RuntimeSignalExtractorAdapter::new();
+        let signals = detect_from_intake_events(&[event], &extractor);
+
+        // Low-content noise events may produce zero signals or only very low
+        // confidence ones.  Assert none exceed 0.8 confidence.
+        let high_conf: Vec<_> = signals.iter().filter(|s| s.confidence > 0.8).collect();
+        assert!(
+            high_conf.is_empty(),
+            "noise event should not produce high-confidence signals; got: {:?}",
+            high_conf
+        );
+    }
+
+    /// `intake_events_to_extractor_input` routing: compiler events land in
+    /// `compiler_output`, panic events in `stack_trace`, generic events in `logs`.
+    #[test]
+    fn intake_events_routing() {
+        // compiler_output: contains "error[E"
+        let compiler_event = make_event(
+            IntakeSourceType::LogFile,
+            "Build error",
+            "error[E0425]: cannot find value `x`",
+            IssueSeverity::High,
+        );
+        // stack_trace: contains thread panic pattern
+        let panic_event = make_event(
+            IntakeSourceType::Sentry,
+            "Panic detected",
+            "thread 'tokio-worker' panicked at 'assertion failed', src/main.rs:5\nstack backtrace:\n   0: std::panicking::begin_panic",
+            IssueSeverity::Critical,
+        );
+        // logs: generic content
+        let log_event = make_event(
+            IntakeSourceType::Github,
+            "PR merged",
+            "feat: add new feature",
+            IssueSeverity::Info,
+        );
+
+        let input = intake_events_to_extractor_input(&[compiler_event, panic_event, log_event]);
+
+        assert!(
+            input.compiler_output.is_some(),
+            "compiler event must populate compiler_output"
+        );
+        assert!(
+            input.stack_trace.is_some(),
+            "panic event must populate stack_trace"
+        );
+        assert!(input.logs.is_some(), "log event must populate logs");
+    }
+
+    /// Full pipeline path: IntakeEvent → Detect → Select stage entry point.
+    ///
+    /// This test wires an `IntakeEvent` with a compiler diagnostic through the
+    /// `detect_from_intake_events` helper, then feeds the resulting signals
+    /// directly into `StandardEvolutionPipeline` via `PipelineContext::signals`.
+    /// It asserts that the Detect stage completes and the Select stage starts.
+    #[test]
+    fn intake_event_detect_select_pipeline_path() {
+        use oris_evolution::{
+            EvolutionPipeline, EvolutionPipelineConfig, PipelineContext, PipelineStageState,
+            StandardEvolutionPipeline,
+        };
+        use oris_evolution::{GeneCandidate, Selector, SelectorInput};
+        use std::sync::Arc;
+
+        // Minimal no-op selector that always returns no candidates.
+        struct NoopSelector;
+        impl Selector for NoopSelector {
+            fn select(&self, _input: &SelectorInput) -> Vec<GeneCandidate> {
+                vec![]
+            }
+        }
+
+        // content has "error[E" → routed to compiler_output
+        let compiler_event = make_event(
+            IntakeSourceType::LogFile,
+            "cargo build failed",
+            "error[E0308]: mismatched types\n  --> src/lib.rs:5:10",
+            IssueSeverity::High,
+        );
+
+        let extractor = RuntimeSignalExtractorAdapter::new();
+        let signals = detect_from_intake_events(&[compiler_event], &extractor);
+
+        // Build a pipeline that only runs Detect + Select (other stages disabled).
+        let config = EvolutionPipelineConfig {
+            enable_execute: false,
+            enable_validate: false,
+            enable_evaluate: false,
+            enable_solidify: false,
+            enable_reuse: false,
+            ..EvolutionPipelineConfig::default()
+        };
+        let pipeline = StandardEvolutionPipeline::new(config, Arc::new(NoopSelector));
+
+        // Pre-populate context with the signals produced by detect_from_intake_events.
+        let mut ctx = PipelineContext::default();
+        ctx.signals = signals.clone();
+
+        let result = pipeline.execute(ctx).expect("pipeline must not error");
+
+        // Detect and Select stages must complete (or skip with no candidates).
+        let detect_state = result
+            .stage_states
+            .iter()
+            .find(|s| s.stage_name == "detect");
+        assert!(
+            detect_state.is_some(),
+            "Detect stage must appear in stage_states"
+        );
+        assert_eq!(
+            detect_state.unwrap().state,
+            PipelineStageState::Completed,
+            "Detect stage must complete"
+        );
+
+        let select_state = result
+            .stage_states
+            .iter()
+            .find(|s| s.stage_name == "select");
+        assert!(
+            select_state.is_some(),
+            "Select stage must appear in stage_states"
+        );
+    }
+}

--- a/crates/oris-evokernel/tests/evolution_feature_wiring.rs
+++ b/crates/oris-evokernel/tests/evolution_feature_wiring.rs
@@ -1,0 +1,206 @@
+//! Integration tests: full path IntakeEvent → Detect → Select stage entry.
+//!
+//! These tests verify that the pipeline integration wiring introduced in
+//! `pipeline_integration.rs` produces the correct observable behaviour when
+//! routed through `StandardEvolutionPipeline`.
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p oris-evokernel --test evolution_feature_wiring
+//! ```
+
+use std::sync::Arc;
+
+use oris_evokernel::adapters::RuntimeSignalExtractorAdapter;
+use oris_evokernel::pipeline_integration::detect_from_intake_events;
+use oris_evolution::{
+    EvolutionPipeline, EvolutionPipelineConfig, GeneCandidate, PipelineContext, PipelineStageState,
+    Selector, SelectorInput, StandardEvolutionPipeline,
+};
+use oris_intake::{IntakeEvent, IntakeSourceType, IssueSeverity};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn make_event(
+    source_type: IntakeSourceType,
+    title: &str,
+    description: &str,
+    severity: IssueSeverity,
+) -> IntakeEvent {
+    IntakeEvent {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        source_type,
+        source_event_id: None,
+        title: title.to_string(),
+        description: description.to_string(),
+        severity,
+        signals: vec![],
+        raw_payload: None,
+        timestamp_ms: 0,
+    }
+}
+
+/// Minimal no-op selector that always returns an empty candidate list.
+struct NoopSelector;
+
+impl Selector for NoopSelector {
+    fn select(&self, _input: &SelectorInput) -> Vec<GeneCandidate> {
+        vec![]
+    }
+}
+
+/// Build a pipeline with Detect + Select enabled; all other stages disabled.
+fn detect_select_pipeline() -> StandardEvolutionPipeline {
+    let config = EvolutionPipelineConfig {
+        enable_execute: false,
+        enable_validate: false,
+        enable_evaluate: false,
+        enable_solidify: false,
+        enable_reuse: false,
+        ..EvolutionPipelineConfig::default()
+    };
+    StandardEvolutionPipeline::new(config, Arc::new(NoopSelector))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Full path: `IntakeEvent` with a `error[E0308]` compiler diagnostic →
+/// `detect_from_intake_events` → `PipelineContext::signals` →
+/// `StandardEvolutionPipeline::execute` → Detect stage `Completed`.
+#[test]
+fn intake_event_compiler_error_reaches_detect_stage() {
+    let event = make_event(
+        IntakeSourceType::LogFile,
+        "cargo build failed",
+        "error[E0308]: mismatched types\n  --> src/lib.rs:5:10\n   |\n5  |     let x: i32 = \"hello\";\n   |                   ^^^^^^^ expected `i32`, found `&str`",
+        IssueSeverity::High,
+    );
+
+    let extractor = RuntimeSignalExtractorAdapter::new();
+    let signals = detect_from_intake_events(&[event], &extractor);
+
+    // At least one signal must be produced for a genuine compiler error.
+    assert!(
+        !signals.is_empty(),
+        "detect_from_intake_events must produce signals for compiler error[E0308]"
+    );
+
+    let mut ctx = PipelineContext::default();
+    ctx.signals = signals;
+
+    let result = detect_select_pipeline()
+        .execute(ctx)
+        .expect("pipeline must not error");
+
+    let detect_stage = result
+        .stage_states
+        .iter()
+        .find(|s| s.stage_name == "detect")
+        .expect("Detect stage must appear in stage_states");
+
+    assert_eq!(
+        detect_stage.state,
+        PipelineStageState::Completed,
+        "Detect stage must be Completed"
+    );
+
+    let select_stage = result
+        .stage_states
+        .iter()
+        .find(|s| s.stage_name == "select")
+        .expect("Select stage must appear in stage_states");
+
+    assert!(
+        matches!(
+            select_stage.state,
+            PipelineStageState::Completed | PipelineStageState::Skipped(_)
+        ),
+        "Select stage must be Completed or Skipped (no candidates); got {:?}",
+        select_stage.state
+    );
+}
+
+/// Full path: `IntakeEvent` with a runtime panic → Detect stage entry.
+#[test]
+fn intake_event_runtime_panic_reaches_detect_stage() {
+    let event = make_event(
+        IntakeSourceType::Sentry,
+        "Worker thread panicked",
+        "thread 'tokio-worker-2' panicked at 'index out of bounds: the len is 3 but the index is 5', src/worker.rs:42",
+        IssueSeverity::Critical,
+    );
+
+    let extractor = RuntimeSignalExtractorAdapter::new();
+    let signals = detect_from_intake_events(&[event], &extractor);
+
+    assert!(
+        !signals.is_empty(),
+        "detect_from_intake_events must produce signals for runtime panic"
+    );
+
+    let mut ctx = PipelineContext::default();
+    ctx.signals = signals;
+
+    let result = detect_select_pipeline()
+        .execute(ctx)
+        .expect("pipeline must not error");
+
+    let detect_stage = result
+        .stage_states
+        .iter()
+        .find(|s| s.stage_name == "detect")
+        .expect("Detect stage must appear");
+
+    assert_eq!(detect_stage.state, PipelineStageState::Completed);
+}
+
+/// When `StandardEvolutionPipeline` is built with a `RuntimeSignalExtractorAdapter`
+/// injected via `with_signal_extractor`, the adapter is called during the Detect
+/// stage and its signals are merged into the pipeline context.
+#[test]
+fn pipeline_with_injected_extractor_calls_detect() {
+    use oris_evokernel::pipeline_integration::intake_events_to_extractor_input;
+
+    let event = make_event(
+        IntakeSourceType::LogFile,
+        "Build error",
+        "error[E0425]: cannot find value `foo` in this scope\n  --> src/main.rs:10:5",
+        IssueSeverity::High,
+    );
+    let extractor_input = intake_events_to_extractor_input(&[event]);
+
+    let extractor = Arc::new(RuntimeSignalExtractorAdapter::new());
+    let config = EvolutionPipelineConfig {
+        enable_execute: false,
+        enable_validate: false,
+        enable_evaluate: false,
+        enable_solidify: false,
+        enable_reuse: false,
+        ..EvolutionPipelineConfig::default()
+    };
+    let pipeline = StandardEvolutionPipeline::new(config, Arc::new(NoopSelector))
+        .with_signal_extractor(extractor);
+
+    // Supply the extractor input via PipelineContext::extractor_input so the
+    // pipeline's Detect stage will call the injected extractor.
+    let mut ctx = PipelineContext::default();
+    ctx.extractor_input = Some(extractor_input);
+
+    let result = pipeline.execute(ctx).expect("pipeline must not error");
+
+    let detect = result
+        .stage_states
+        .iter()
+        .find(|s| s.stage_name == "detect")
+        .expect("Detect stage must appear");
+
+    assert_eq!(
+        detect.state,
+        PipelineStageState::Completed,
+        "Detect stage with injected extractor must complete"
+    );
+}

--- a/crates/oris-runtime/Cargo.toml
+++ b/crates/oris-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-runtime"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 oris-execution-runtime = { version = "0.3.0", path = "../oris-execution-runtime", default-features = false }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel", default-features = false }
-oris-evokernel = { version = "0.13.0", path = "../oris-evokernel", optional = true }
+oris-evokernel = { version = "0.14.0", path = "../oris-evokernel", optional = true }
 scraper = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1.80"

--- a/crates/oris-runtime/tests/evolution_feature_wiring.rs
+++ b/crates/oris-runtime/tests/evolution_feature_wiring.rs
@@ -14,6 +14,8 @@ fn assert_type<T>() {}
 #[test]
 fn full_evolution_experimental_paths_resolve() {
     let _ = oris_runtime::evolution::extract_deterministic_signals;
+    let _ = oris_runtime::evolution::detect_from_intake_events;
+    let _ = oris_runtime::evolution::intake_events_to_extractor_input;
     let _ = oris_runtime::evolution::prepare_mutation;
     let _ = oris_runtime::evolution::EvoKernel::<FeatureState>::capture_from_proposal;
     let _ = oris_runtime::evolution::EvoKernel::<FeatureState>::feedback_for_agent;


### PR DESCRIPTION
Closes #297

## Summary
Wire intake events into the evolution detect stage via oris-evokernel pipeline integration helpers.

## Validation
- cargo fmt --all -- --check
- cargo test -p oris-evokernel --test evolution_feature_wiring
- cargo test -p oris-evokernel
- cargo test -p oris-runtime --test evolution_feature_wiring --features full-evolution-experimental
- cargo build --verbose --all --release --all-features
- cargo test --release --all-features
- cargo publish -p oris-evokernel --all-features --dry-run
- cargo publish -p oris-evokernel --all-features
- cargo publish -p oris-runtime --all-features
- Released as oris-evokernel v0.14.0 and oris-runtime v0.42.0
