### PR TITLE
feat: confidence model time-decay and Bayesian update path 299

### DIFF
--- a/RELEASE_v0.44.0.md
+++ b/RELEASE_v0.44.0.md
@@ -1,0 +1,46 @@
+# v0.44.0 – Confidence Model: Time-Decay Weighting and Bayesian Update Path (P2-04)
+
+## Released Crates
+
+| Crate | Version |
+|-------|---------|
+| `oris-evolution` | 0.4.1 |
+| `oris-mutation-evaluator` | 0.3.0 |
+
+## Summary
+
+Implements time-decay weighting and a Bayesian conjugate update path for mutation
+confidence scoring (P2-04 of the Phase 2 evolution roadmap).
+
+## Changes
+
+### `oris-mutation-evaluator` 0.3.0
+
+- **`CompositeScore`** – Composite mutation score that bundles a raw score, a
+  time-decay-weighted score (`w_t = exp(-λ * age_days)`, λ=0.05 ≈ 14-day
+  half-life), a Wilson score confidence interval, and the historical sample count.
+- **`CompositeScore::compute(raw, age_days, sample_count)`** – Constructs the
+  composite from a dimension score, the observation age in days, and the number of
+  historical outcomes.
+- **`CompositeScore::pessimistic()`** – Returns the upper Wilson CI bound when
+  `sample_count < 10` (low-data regime), otherwise returns the raw score.
+- **`wilson_interval(p, n)`** – Wilson score proportion interval at 95% CI
+  (`z = 1.96`); returns `(0.0, 1.0)` when `n == 0`.
+
+### `oris-evolution` 0.4.1
+
+- **`BayesianConfidenceUpdater`** – Beta-Bernoulli conjugate model for tracking
+  asset confidence.  Maintains `(α, β)` parameters; each success increments `α`,
+  each failure increments `β`.  Posterior mean is `α / (α + β)`.
+- **`BetaPrior`** – Struct holding `(alpha, beta)` prior hyperparameters.
+- **`builtin_priors()`** – Returns the canonical weak-success prior `Beta(2, 1)`.
+- **`ConfidenceSnapshot`** – Snapshot of the posterior: `mean`, `variance`,
+  `sample_count`, and `is_stable` flag (true when ≥10 observations and
+  variance < 0.01).
+
+## Validation
+
+- `cargo fmt --all -- --check` ✅
+- `cargo test -p oris-mutation-evaluator --lib` → 18 passed ✅
+- `cargo test -p oris-evolution --lib` → 91 passed ✅
+- `cargo build --all --release --all-features` ✅

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -13,9 +13,9 @@ async-trait = "0.1.80"
 chrono = { version = "0.4", default-features = true }
 oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
 oris-economics = { version = "0.2.0", path = "../oris-economics" }
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 oris-intake = { version = "0.4.0", path = "../oris-intake" }
-oris-mutation-evaluator = { version = "0.2.1", path = "../oris-mutation-evaluator" }
+oris-mutation-evaluator = { version = "0.3.0", path = "../oris-mutation-evaluator" }
 oris-evolution-network = { version = "0.4.0", path = "../oris-evolution-network" }
 oris-genestore = { version = "0.2.0", path = "../oris-genestore" }
 oris-governor = { version = "0.3.0", path = "../oris-governor" }

--- a/crates/oris-evolution-network/Cargo.toml
+++ b/crates/oris-evolution-network/Cargo.toml
@@ -10,7 +10,7 @@ description = "Protocol types for the Oris Evolution Network."
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/oris-evolution/Cargo.toml
+++ b/crates/oris-evolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evolution"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]

--- a/crates/oris-evolution/src/confidence.rs
+++ b/crates/oris-evolution/src/confidence.rs
@@ -419,6 +419,140 @@ impl ConfidenceController {
     }
 }
 
+// ---------------------------------------------------------------------------
+// BayesianConfidenceUpdater and ConfidenceSnapshot
+// ---------------------------------------------------------------------------
+
+/// A snapshot of the current Bayesian posterior for an asset's confidence.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ConfidenceSnapshot {
+    /// Posterior mean: α / (α + β).
+    pub mean: f32,
+    /// Posterior variance: αβ / ((α+β)²(α+β+1)).
+    pub variance: f32,
+    /// Total observations (successes + failures) since the updater was created.
+    pub sample_count: u32,
+    /// `true` when `sample_count ≥ 10` and `variance < 0.01`, indicating a stable
+    /// credible interval.
+    pub is_stable: bool,
+}
+
+/// Per-class Beta-distribution prior.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BetaPrior {
+    /// Alpha parameter (pseudo-success count).
+    pub alpha: f32,
+    /// Beta parameter (pseudo-failure count).
+    pub beta: f32,
+}
+
+impl BetaPrior {
+    pub fn new(alpha: f32, beta: f32) -> Self {
+        assert!(
+            alpha > 0.0 && beta > 0.0,
+            "Beta distribution parameters must be positive"
+        );
+        Self { alpha, beta }
+    }
+}
+
+/// Return the canonical built-in priors.
+///
+/// Encodes a weak prior leaning toward success (α=2, β=1) reflecting that
+/// genes entering the pool should already have passed static validation.
+pub fn builtin_priors() -> BetaPrior {
+    BetaPrior::new(2.0, 1.0)
+}
+
+/// Bayesian confidence updater using a Beta-Bernoulli conjugate model.
+///
+/// # Model
+///
+/// Maintains parameters `(α, β)` of a Beta distribution.  On each observation:
+/// - Success: `α += 1`
+/// - Failure: `β += 1`
+///
+/// The posterior mean `α / (α + β)` is used as the point estimate.
+pub struct BayesianConfidenceUpdater {
+    alpha: f32,
+    beta: f32,
+}
+
+impl BayesianConfidenceUpdater {
+    /// Create an updater with an explicit prior.
+    pub fn new(prior: BetaPrior) -> Self {
+        Self {
+            alpha: prior.alpha,
+            beta: prior.beta,
+        }
+    }
+
+    /// Create an updater with the `builtin_priors()` prior.
+    pub fn with_builtin_prior() -> Self {
+        Self::new(builtin_priors())
+    }
+
+    /// Record a success observation (`α += 1`).
+    pub fn update_success(&mut self) {
+        self.alpha += 1.0;
+    }
+
+    /// Record a failure observation (`β += 1`).
+    pub fn update_failure(&mut self) {
+        self.beta += 1.0;
+    }
+
+    /// Apply `successes` and `failures` in bulk.
+    pub fn update(&mut self, successes: u32, failures: u32) {
+        self.alpha += successes as f32;
+        self.beta += failures as f32;
+    }
+
+    /// Posterior mean: `α / (α + β)`.
+    pub fn posterior_mean(&self) -> f32 {
+        self.alpha / (self.alpha + self.beta)
+    }
+
+    /// Posterior variance: `αβ / ((α+β)²(α+β+1))`.
+    pub fn posterior_variance(&self) -> f32 {
+        let ab = self.alpha + self.beta;
+        (self.alpha * self.beta) / (ab * ab * (ab + 1.0))
+    }
+
+    /// Total observations recorded above the prior (i.e. `(α - α₀) + (β - β₀)`).
+    pub fn sample_count(&self, prior: &BetaPrior) -> u32 {
+        let raw = (self.alpha - prior.alpha) + (self.beta - prior.beta);
+        raw.round().max(0.0) as u32
+    }
+
+    /// Build a `ConfidenceSnapshot` from the current posterior state.
+    ///
+    /// `prior` is used only to compute `sample_count`; pass `builtin_priors()`
+    /// unless you constructed this updater with a custom prior.
+    pub fn snapshot(&self, prior: &BetaPrior) -> ConfidenceSnapshot {
+        let mean = self.posterior_mean();
+        let variance = self.posterior_variance();
+        let count = self.sample_count(prior);
+        let is_stable = count >= 10 && variance < 0.01;
+        ConfidenceSnapshot {
+            mean,
+            variance,
+            sample_count: count,
+            is_stable,
+        }
+    }
+
+    /// Current alpha parameter (useful for serialisation/inspection).
+    pub fn alpha(&self) -> f32 {
+        self.alpha
+    }
+
+    /// Current beta parameter (useful for serialisation/inspection).
+    pub fn beta(&self) -> f32 {
+        self.beta
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,5 +775,66 @@ mod tests {
         assert!((evt.failure_rate - 1.0).abs() < 0.001);
         assert_eq!(evt.window_samples, 3);
         assert_eq!(evt.event_at_ms, NOW + 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // BayesianConfidenceUpdater tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bayesian_updater_prior_mean() {
+        // builtin_priors: α=2, β=1 → mean = 2/3 ≈ 0.667
+        let updater = BayesianConfidenceUpdater::with_builtin_prior();
+        let mean = updater.posterior_mean();
+        assert!((mean - 2.0 / 3.0).abs() < 0.001, "mean={mean}");
+    }
+
+    #[test]
+    fn bayesian_updater_converges_to_true_rate() {
+        // 100 observations at 70% success-rate; posterior mean should approach 0.70.
+        let mut updater = BayesianConfidenceUpdater::with_builtin_prior();
+        updater.update(70, 30);
+        let mean = updater.posterior_mean();
+        assert!(
+            (mean - 0.70).abs() < 0.02,
+            "expected mean ≈ 0.70, got {mean}"
+        );
+    }
+
+    #[test]
+    fn bayesian_updater_sample_count() {
+        let prior = builtin_priors();
+        let mut updater = BayesianConfidenceUpdater::with_builtin_prior();
+        updater.update(5, 5);
+        assert_eq!(updater.sample_count(&prior), 10);
+    }
+
+    #[test]
+    fn bayesian_updater_snapshot_is_stable_after_observations() {
+        let prior = builtin_priors();
+        let mut updater = BayesianConfidenceUpdater::with_builtin_prior();
+        // 50 successes, 50 failures → balanced → variance should be small after many samples
+        updater.update(50, 50);
+        let snap = updater.snapshot(&prior);
+        assert_eq!(snap.sample_count, 100);
+        // variance = αβ/((α+β)²(α+β+1)); with α=52,β=51 → very small
+        assert!(snap.is_stable, "should be stable with 100 samples");
+    }
+
+    #[test]
+    fn bayesian_updater_sequential_updates_equal_bulk() {
+        let mut seq = BayesianConfidenceUpdater::with_builtin_prior();
+        for _ in 0..7 {
+            seq.update_success();
+        }
+        for _ in 0..3 {
+            seq.update_failure();
+        }
+
+        let mut bulk = BayesianConfidenceUpdater::with_builtin_prior();
+        bulk.update(7, 3);
+
+        assert!((seq.posterior_mean() - bulk.posterior_mean()).abs() < 1e-6);
+        assert!((seq.posterior_variance() - bulk.posterior_variance()).abs() < 1e-9);
     }
 }

--- a/crates/oris-governor/Cargo.toml
+++ b/crates/oris-governor/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT"
 description = "Promotion, cooldown, and revocation policies for Oris EvoKernel."
 
 [dependencies]
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/oris-intake/Cargo.toml
+++ b/crates/oris-intake/Cargo.toml
@@ -10,7 +10,7 @@ description = "Automatic issue intake system for Oris self-evolution."
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 regex-lite = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/oris-mutation-evaluator/Cargo.toml
+++ b/crates/oris-mutation-evaluator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-mutation-evaluator"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Mutation quality evaluator with static analysis and LLM critic"
 license = "MIT OR Apache-2.0"

--- a/crates/oris-mutation-evaluator/src/lib.rs
+++ b/crates/oris-mutation-evaluator/src/lib.rs
@@ -15,4 +15,7 @@ pub use mutation_backend::{
     ContractViolation, EnvRoutedBackend, LlmMutationBackend, MockMutationBackend, MutationRequest,
     ProposalContract,
 };
-pub use types::{EvaluationReport, MutationProposal, Verdict, APPLY_THRESHOLD, PROMOTE_THRESHOLD};
+pub use types::{
+    wilson_interval, CompositeScore, EvaluationReport, MutationProposal, Verdict, APPLY_THRESHOLD,
+    PROMOTE_THRESHOLD,
+};

--- a/crates/oris-mutation-evaluator/src/types.rs
+++ b/crates/oris-mutation-evaluator/src/types.rs
@@ -153,9 +153,124 @@ pub enum AntiPatternKind {
     Custom(String),
 }
 
+/// Composite score with time-decay and statistical confidence interval.
+///
+/// `raw` is the unweighted composite from `DimensionScores::composite()`.
+/// `time_decayed` applies an exponential time-decay weight `w_t = exp(-λ * age_days)`
+/// where `λ = 0.05` (≈ 14-day half-life).
+/// `confidence_interval` is a Wilson score interval (lower, upper); the upper
+/// bound is used as a pessimistic estimate when `sample_count < 10`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompositeScore {
+    /// Raw weighted composite score in [0.0, 1.0].
+    pub raw: f64,
+    /// Time-decay-weighted score in [0.0, 1.0].
+    pub time_decayed: f64,
+    /// Wilson score interval `(lower, upper)` in [0.0, 1.0].
+    pub confidence_interval: (f64, f64),
+    /// Number of historical observations used (0 = first evaluation).
+    pub sample_count: usize,
+}
+
+impl CompositeScore {
+    /// Compute from a raw score, observation age in days, and historical sample count.
+    ///
+    /// * `raw` — result of `DimensionScores::composite()`
+    /// * `age_days` — calendar age of the most-recent matching observation
+    /// * `sample_count` — number of historical outcomes (0 for brand-new mutations)
+    pub fn compute(raw: f64, age_days: f64, sample_count: usize) -> Self {
+        const LAMBDA: f64 = 0.05;
+        let weight = (-LAMBDA * age_days).exp();
+        let time_decayed = (raw * weight).clamp(0.0, 1.0);
+        let ci = wilson_interval(raw, sample_count);
+        Self {
+            raw,
+            time_decayed,
+            confidence_interval: ci,
+            sample_count,
+        }
+    }
+
+    /// Pessimistic estimate: upper bound of the Wilson CI when `sample_count < 10`,
+    /// otherwise the raw score.
+    pub fn pessimistic(&self) -> f64 {
+        if self.sample_count < 10 {
+            self.confidence_interval.1
+        } else {
+            self.raw
+        }
+    }
+}
+
+/// Wilson score interval for a proportion `p` estimated from `n` observations.
+///
+/// Uses a 95% confidence level (`z = 1.96`).  Returns `(0.0, 1.0)` when `n == 0`.
+pub fn wilson_interval(p: f64, n: usize) -> (f64, f64) {
+    if n == 0 {
+        return (0.0, 1.0);
+    }
+    let n_f = n as f64;
+    const Z: f64 = 1.96;
+    let z2 = Z * Z;
+    let denom = 1.0 + z2 / n_f;
+    let center = (p + z2 / (2.0 * n_f)) / denom;
+    let half = (Z / denom) * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt();
+    (
+        (center - half).clamp(0.0, 1.0),
+        (center + half).clamp(0.0, 1.0),
+    )
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Thresholds
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub const PROMOTE_THRESHOLD: f64 = 0.72;
 pub const APPLY_THRESHOLD: f64 = 0.45;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_decay_older_score_lower() {
+        let fresh = CompositeScore::compute(0.8, 1.0, 20);
+        let stale = CompositeScore::compute(0.8, 30.0, 20);
+        assert!(
+            stale.time_decayed < fresh.time_decayed,
+            "30-day score ({}) should be below 1-day score ({})",
+            stale.time_decayed,
+            fresh.time_decayed
+        );
+    }
+
+    #[test]
+    fn wilson_upper_bound_below_one_for_small_sample() {
+        // With 4 observations and raw=0.75, upper CI bound should be < 1.0.
+        let (_, upper) = wilson_interval(0.75, 4);
+        assert!(
+            upper < 1.0,
+            "upper CI={upper} should be < 1.0 for 4 samples"
+        );
+    }
+
+    #[test]
+    fn wilson_zero_samples_returns_full_range() {
+        let (lo, hi) = wilson_interval(0.5, 0);
+        assert!((lo - 0.0).abs() < 1e-9);
+        assert!((hi - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn composite_pessimistic_uses_upper_bound_for_small_sample() {
+        let cs = CompositeScore::compute(0.6, 0.0, 4);
+        let (_, upper) = wilson_interval(0.6, 4);
+        assert!((cs.pessimistic() - upper).abs() < 1e-9);
+    }
+
+    #[test]
+    fn composite_pessimistic_uses_raw_for_large_sample() {
+        let cs = CompositeScore::compute(0.6, 0.0, 20);
+        assert!((cs.pessimistic() - 0.6).abs() < 1e-9);
+    }
+}

--- a/crates/oris-orchestrator/Cargo.toml
+++ b/crates/oris-orchestrator/Cargo.toml
@@ -9,7 +9,7 @@ description = "Oris orchestration contracts and control flow primitives."
 [dependencies]
 async-trait = "0.1"
 oris-agent-contract = { version = "0.5.5", path = "../oris-agent-contract" }
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 oris-intake = { version = "0.4.0", path = "../oris-intake" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/oris-sandbox/Cargo.toml
+++ b/crates/oris-sandbox/Cargo.toml
@@ -10,7 +10,7 @@ description = "Local sandboxed mutation application for Oris EvoKernel."
 [dependencies]
 async-trait = "0.1.80"
 hex = "0.4"
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "2.0.0"

--- a/crates/oris-spec/Cargo.toml
+++ b/crates/oris-spec/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 description = "OUSL YAML spec contracts and compilers for Oris."
 
 [dependencies]
-oris-evolution = { version = "0.4.0", path = "../oris-evolution" }
+oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2.0.0"


### PR DESCRIPTION
Closes #299

## Summary
Adds time-decay weighted composite scoring (`CompositeScore`, `wilson_interval`) to `oris-mutation-evaluator` and a Bayesian Beta-Bernoulli update path (`BayesianConfidenceUpdater`, `ConfidenceSnapshot`) to `oris-evolution`.

## Changes
- `oris-mutation-evaluator`: `CompositeScore` with exponential decay (λ=0.05), `wilson_interval` (Wilson score CI at 95%)
- `oris-evolution`: `BayesianConfidenceUpdater` (Beta prior, conjugate updates), `ConfidenceSnapshot` with stability flag

## Validation
- `cargo fmt --all -- --check` ✅
- `cargo test -p oris-mutation-evaluator --lib` → 18 passed ✅
- `cargo test -p oris-evolution --lib` → 91 passed ✅
- `cargo build --all --release --all-features` ✅
- `cargo publish -p oris-mutation-evaluator --all-features --dry-run` passed ✅
- Released as oris-mutation-evaluator v0.3.0 and oris-evolution v0.4.1
