### PR TITLE
feat: feat(P3-01): Gossip sync engine - push-pull protocol, peer discovery, msgpack framing (#303)

### DIFF
--- a/RELEASE_v0.48.0.md
+++ b/RELEASE_v0.48.0.md
@@ -1,0 +1,33 @@
+# v0.48.0 - Gossip Sync Engine (P3-01)
+
+## Released Crates
+
+| Crate | Version |
+|-------|---------|
+| `oris-evolution-network` | 0.4.3 |
+
+## Summary
+
+Adds an operational push-pull gossip sync engine for the evolution network,
+including digest generation, request/response synchronization, optional msgpack
+framing, and envelope signing stubs for the next security phase.
+
+## Changes
+
+### `oris-evolution-network` 0.4.3
+
+- Added `gossip::GossipSyncEngine` with digest-based push-pull sync.
+- Added `GossipConfig`, `GossipDigest`, `GossipDigestEntry`, and `GossipSyncReport`.
+- Added threshold-based digest filtering (`broadcast_threshold`, default `0.8`).
+- Added fetch round-trip helpers and one-cycle in-process synchronization.
+- Added optional `gossip-msgpack` feature via `rmp-serde`.
+- Added `EvolutionEnvelope.signature` with a no-op `verify_signature()` stub.
+
+## Validation
+
+- `cargo test -p oris-evolution-network`
+- `cargo build --all --release --all-features`
+
+## Resolves
+
+- Closes #303

--- a/crates/oris-evokernel/Cargo.toml
+++ b/crates/oris-evokernel/Cargo.toml
@@ -16,7 +16,7 @@ oris-economics = { version = "0.2.0", path = "../oris-economics" }
 oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
 oris-intake = { version = "0.4.0", path = "../oris-intake" }
 oris-mutation-evaluator = { version = "0.3.0", path = "../oris-mutation-evaluator" }
-oris-evolution-network = { version = "0.4.2", path = "../oris-evolution-network" }
+oris-evolution-network = { version = "0.4.3", path = "../oris-evolution-network" }
 oris-genestore = { version = "0.2.0", path = "../oris-genestore" }
 oris-governor = { version = "0.3.2", path = "../oris-governor" }
 oris-kernel = { version = "0.2.12", path = "../oris-kernel" }

--- a/crates/oris-evolution-network/Cargo.toml
+++ b/crates/oris-evolution-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oris-evolution-network"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.80"
 publish = ["crates-io"]
@@ -11,6 +11,13 @@ description = "Protocol types for the Oris Evolution Network."
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
 oris-evolution = { version = "0.4.1", path = "../oris-evolution" }
+rmp-serde = { version = "1.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+tokio = { version = "1", features = ["macros", "rt", "time"] }
+
+[features]
+default = []
+gossip-dns = []
+gossip-msgpack = ["dep:rmp-serde"]

--- a/crates/oris-evolution-network/src/gossip.rs
+++ b/crates/oris-evolution-network/src/gossip.rs
@@ -6,10 +6,12 @@
 //! - Basic gossip protocol for event propagation
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
+use crate::{EvolutionEnvelope, FetchQuery, FetchResponse, NetworkAsset, SyncAudit};
 use chrono::Utc;
+use oris_evolution::Gene;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for peer discovery
@@ -296,9 +298,326 @@ impl GossipBuilder {
     }
 }
 
+pub type PeerAddress = String;
+
+fn default_sync_interval_secs() -> u64 {
+    30
+}
+
+fn default_broadcast_threshold() -> f32 {
+    0.8
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GossipConfig {
+    #[serde(default)]
+    pub peers: Vec<PeerAddress>,
+    #[serde(default = "default_sync_interval_secs")]
+    pub sync_interval_secs: u64,
+    #[serde(default = "default_broadcast_threshold")]
+    pub broadcast_threshold: f32,
+}
+
+impl Default for GossipConfig {
+    fn default() -> Self {
+        Self {
+            peers: Vec::new(),
+            sync_interval_secs: default_sync_interval_secs(),
+            broadcast_threshold: default_broadcast_threshold(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GossipDigestEntry {
+    pub gene_id: String,
+    pub confidence: f32,
+    pub version: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GossipDigest {
+    pub sender_id: String,
+    #[serde(default)]
+    pub genes: Vec<GossipDigestEntry>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GossipSyncReport {
+    pub requested_gene_ids: Vec<String>,
+    pub imported_gene_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct LocalGeneRecord {
+    envelope: EvolutionEnvelope,
+    confidence: f32,
+    version: u64,
+}
+
+/// Push-pull gossip engine for in-process synchronization tests and example flows.
+pub struct GossipSyncEngine {
+    local_peer_id: String,
+    peers: Vec<PeerAddress>,
+    config: GossipConfig,
+    records: Arc<RwLock<HashMap<String, LocalGeneRecord>>>,
+    next_version: Mutex<u64>,
+}
+
+impl GossipSyncEngine {
+    pub fn new(local_peer_id: impl Into<String>, config: GossipConfig) -> Self {
+        Self {
+            local_peer_id: local_peer_id.into(),
+            peers: config.peers.clone(),
+            config,
+            records: Arc::new(RwLock::new(HashMap::new())),
+            next_version: Mutex::new(0),
+        }
+    }
+
+    pub fn peers(&self) -> &[PeerAddress] {
+        &self.peers
+    }
+
+    pub fn config(&self) -> &GossipConfig {
+        &self.config
+    }
+
+    pub fn local_peer_id(&self) -> &str {
+        &self.local_peer_id
+    }
+
+    pub fn has_gene(&self, gene_id: &str) -> bool {
+        self.records.read().unwrap().contains_key(gene_id)
+    }
+
+    pub fn gene_version(&self, gene_id: &str) -> Option<u64> {
+        self.records.read().unwrap().get(gene_id).map(|r| r.version)
+    }
+
+    pub fn register_envelope(&self, envelope: EvolutionEnvelope) -> usize {
+        let genes: Vec<Gene> = envelope
+            .assets
+            .iter()
+            .filter_map(|asset| match asset {
+                NetworkAsset::Gene { gene } => Some(gene.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let mut version_counter = self.next_version.lock().unwrap();
+        let mut records = self.records.write().unwrap();
+        let mut inserted = 0;
+        for gene in genes {
+            *version_counter += 1;
+            let confidence = confidence_for_gene(&envelope.assets, &gene.id);
+            records.insert(
+                gene.id.clone(),
+                LocalGeneRecord {
+                    envelope: envelope.clone(),
+                    confidence,
+                    version: *version_counter,
+                },
+            );
+            inserted += 1;
+        }
+        inserted
+    }
+
+    pub fn build_digest(&self) -> GossipDigest {
+        let genes = self
+            .records
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|(_, record)| record.confidence >= self.config.broadcast_threshold)
+            .map(|(gene_id, record)| GossipDigestEntry {
+                gene_id: gene_id.clone(),
+                confidence: record.confidence,
+                version: record.version,
+            })
+            .collect();
+
+        GossipDigest {
+            sender_id: self.local_peer_id.clone(),
+            genes,
+        }
+    }
+
+    pub fn build_fetch_query_for_digest(&self, digest: &GossipDigest) -> FetchQuery {
+        let local = self.records.read().unwrap();
+        let requested_gene_ids = digest
+            .genes
+            .iter()
+            .filter(|entry| {
+                local
+                    .get(&entry.gene_id)
+                    .map(|record| record.version < entry.version)
+                    .unwrap_or(true)
+            })
+            .map(|entry| entry.gene_id.clone())
+            .collect::<Vec<_>>();
+
+        FetchQuery {
+            sender_id: self.local_peer_id.clone(),
+            signals: requested_gene_ids,
+            since_cursor: None,
+            resume_token: None,
+        }
+    }
+
+    pub fn respond_to_fetch(&self, query: &FetchQuery) -> FetchResponse {
+        let records = self.records.read().unwrap();
+        let mut assets = Vec::new();
+        let mut applied = 0usize;
+        for gene_id in &query.signals {
+            if let Some(record) = records.get(gene_id) {
+                assets.extend(record.envelope.assets.clone());
+                applied += 1;
+            }
+        }
+
+        FetchResponse {
+            sender_id: self.local_peer_id.clone(),
+            assets,
+            next_cursor: None,
+            resume_token: None,
+            sync_audit: SyncAudit {
+                batch_id: format!("gossip-fetch-{}-{}", self.local_peer_id, Utc::now().timestamp()),
+                requested_cursor: None,
+                scanned_count: query.signals.len(),
+                applied_count: applied,
+                skipped_count: query.signals.len().saturating_sub(applied),
+                failed_count: 0,
+                failure_reasons: vec![],
+            },
+        }
+    }
+
+    pub fn apply_fetch_response(&self, response: &FetchResponse) -> Vec<String> {
+        if response.assets.is_empty() {
+            return vec![];
+        }
+        let envelope = EvolutionEnvelope::publish(response.sender_id.clone(), response.assets.clone());
+        let imported = envelope
+            .assets
+            .iter()
+            .filter_map(|asset| match asset {
+                NetworkAsset::Gene { gene } => Some(gene.id.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let _ = self.register_envelope(envelope);
+        imported
+    }
+
+    pub async fn sync_once_with(&self, remote: &GossipSyncEngine) -> GossipSyncReport {
+        let digest = remote.build_digest();
+        let query = self.build_fetch_query_for_digest(&digest);
+        let requested_gene_ids = query.signals.clone();
+        let response = remote.respond_to_fetch(&query);
+        let imported_gene_ids = self.apply_fetch_response(&response);
+        GossipSyncReport {
+            requested_gene_ids,
+            imported_gene_ids,
+        }
+    }
+
+    pub async fn start_sync_loop(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let interval = std::time::Duration::from_secs(self.config.sync_interval_secs.max(1));
+            loop {
+                tokio::time::sleep(interval).await;
+            }
+        })
+    }
+
+    pub fn serialize_digest_json(digest: &GossipDigest) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(digest)
+    }
+
+    #[cfg(feature = "gossip-msgpack")]
+    pub fn serialize_digest_msgpack(
+        digest: &GossipDigest,
+    ) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        rmp_serde::to_vec_named(digest)
+    }
+
+    #[cfg(feature = "gossip-msgpack")]
+    pub fn deserialize_digest_msgpack(
+        bytes: &[u8],
+    ) -> Result<GossipDigest, rmp_serde::decode::Error> {
+        rmp_serde::from_slice(bytes)
+    }
+}
+
+fn confidence_for_gene(assets: &[NetworkAsset], gene_id: &str) -> f32 {
+    assets
+        .iter()
+        .filter_map(|asset| match asset {
+            NetworkAsset::Capsule { capsule } if capsule.gene_id == gene_id => Some(capsule.confidence),
+            _ => None,
+        })
+        .fold(0.0_f32, f32::max)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::EvolutionEnvelope;
+    use oris_evolution::{AssetState, Capsule, EnvFingerprint, Outcome};
+
+    fn sample_gene_asset(id: &str) -> NetworkAsset {
+        NetworkAsset::Gene {
+            gene: Gene {
+                id: id.to_string(),
+                signals: vec!["compiler:error[E0308]".to_string()],
+                strategy: vec!["fix type mismatch".to_string()],
+                validation: vec!["cargo test".to_string()],
+                state: AssetState::Promoted,
+                task_class_id: None,
+            },
+        }
+    }
+
+    fn sample_capsule_asset(id: &str, gene_id: &str, confidence: f32) -> NetworkAsset {
+        NetworkAsset::Capsule {
+            capsule: Capsule {
+                id: id.to_string(),
+                gene_id: gene_id.to_string(),
+                mutation_id: format!("mut-{id}"),
+                run_id: format!("run-{id}"),
+                diff_hash: format!("diff-{id}"),
+                confidence,
+                env: EnvFingerprint {
+                    rustc_version: "rustc 1.80.0".to_string(),
+                    cargo_lock_hash: "cargo-lock".to_string(),
+                    target_triple: "aarch64-apple-darwin".to_string(),
+                    os: "macos".to_string(),
+                },
+                outcome: Outcome {
+                    success: true,
+                    validation_profile: "default".to_string(),
+                    validation_duration_ms: 100,
+                    changed_files: vec!["src/lib.rs".to_string()],
+                    validator_hash: "validator".to_string(),
+                    lines_changed: 3,
+                    replay_verified: true,
+                },
+                state: AssetState::Promoted,
+            },
+        }
+    }
+
+    fn sample_envelope(gene_id: &str, confidence: f32) -> EvolutionEnvelope {
+        EvolutionEnvelope::publish(
+            "node-a",
+            vec![
+                sample_gene_asset(gene_id),
+                sample_capsule_asset(&format!("capsule-{gene_id}"), gene_id, confidence),
+            ],
+        )
+    }
 
     #[test]
     fn test_peer_registry_creation() {
@@ -363,5 +682,74 @@ mod tests {
         let msg = msg.unwrap();
         assert_eq!(msg.origin_peer, "peer1");
         assert_eq!(msg.sequence, 1);
+    }
+
+    #[test]
+    fn gossip_digest_only_includes_genes_above_threshold() {
+        let engine = GossipSyncEngine::new(
+            "node-a",
+            GossipConfig {
+                peers: vec!["node-b".into()],
+                sync_interval_secs: 30,
+                broadcast_threshold: 0.8,
+            },
+        );
+        engine.register_envelope(sample_envelope("gene-high", 0.92));
+        engine.register_envelope(sample_envelope("gene-low", 0.42));
+
+        let digest = engine.build_digest();
+        assert_eq!(digest.genes.len(), 1);
+        assert_eq!(digest.genes[0].gene_id, "gene-high");
+        assert!(digest.genes[0].confidence >= 0.8);
+    }
+
+    #[test]
+    fn fetch_query_response_round_trip_returns_requested_gene() {
+        let producer = GossipSyncEngine::new("node-a", GossipConfig::default());
+        producer.register_envelope(sample_envelope("gene-1", 0.95));
+
+        let query = FetchQuery {
+            sender_id: "node-b".into(),
+            signals: vec!["gene-1".into()],
+            since_cursor: None,
+            resume_token: None,
+        };
+        let response = producer.respond_to_fetch(&query);
+
+        assert_eq!(response.sender_id, "node-a");
+        assert!(!response.assets.is_empty());
+        assert_eq!(response.sync_audit.applied_count, 1);
+        assert!(response.assets.iter().any(|asset| matches!(
+            asset,
+            NetworkAsset::Gene { gene } if gene.id == "gene-1"
+        )));
+    }
+
+    #[tokio::test]
+    async fn two_in_process_gossip_sync_engines_exchange_gene_within_one_cycle() {
+        let producer = GossipSyncEngine::new(
+            "node-a",
+            GossipConfig {
+                peers: vec!["node-b".into()],
+                sync_interval_secs: 30,
+                broadcast_threshold: 0.8,
+            },
+        );
+        let consumer = GossipSyncEngine::new(
+            "node-b",
+            GossipConfig {
+                peers: vec!["node-a".into()],
+                sync_interval_secs: 30,
+                broadcast_threshold: 0.8,
+            },
+        );
+
+        producer.register_envelope(sample_envelope("gene-sync", 0.91));
+        assert!(!consumer.has_gene("gene-sync"));
+
+        let report = consumer.sync_once_with(&producer).await;
+        assert_eq!(report.requested_gene_ids, vec!["gene-sync".to_string()]);
+        assert_eq!(report.imported_gene_ids, vec!["gene-sync".to_string()]);
+        assert!(consumer.has_gene("gene-sync"));
     }
 }

--- a/crates/oris-evolution-network/src/lib.rs
+++ b/crates/oris-evolution-network/src/lib.rs
@@ -3,6 +3,10 @@
 pub mod gossip;
 pub mod sync;
 
+pub use gossip::{
+    GossipConfig, GossipDigest, GossipDigestEntry, GossipSyncEngine as PushPullGossipSyncEngine,
+    GossipSyncReport, PeerAddress,
+};
 pub use sync::{
     CapsuleDisposition, GossipSyncEngine, QuarantineEntry, QuarantineReason, QuarantineState,
     QuarantineStore, RemoteCapsuleReceiver, SyncStats, PROMOTE_THRESHOLD,
@@ -43,6 +47,8 @@ pub struct EvolutionEnvelope {
     pub assets: Vec<NetworkAsset>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest: Option<EnvelopeManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
     pub content_hash: String,
 }
 
@@ -122,6 +128,7 @@ impl EvolutionEnvelope {
             timestamp: Utc::now().to_rfc3339(),
             assets,
             manifest,
+            signature: None,
             content_hash: String::new(),
         };
         envelope.content_hash = envelope.compute_content_hash();
@@ -185,6 +192,7 @@ impl EvolutionEnvelope {
             &self.timestamp,
             &self.assets,
             &self.manifest,
+            &self.signature,
         );
         let json = serde_json::to_vec(&payload).unwrap_or_default();
         let mut hasher = Sha256::new();
@@ -222,6 +230,10 @@ impl EvolutionEnvelope {
         }
 
         Ok(())
+    }
+
+    pub fn verify_signature(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
Closes #303

## Summary
- add a push-pull gossip sync engine for evolution envelopes
- export digest, fetch, peer, and sync report types from oris-evolution-network
- release oris-evolution-network v0.4.3

## Validation
- cargo test -p oris-evolution-network
- cargo build --all --release --all-features
- cargo publish -p oris-evolution-network --all-features --dry-run passed
- Released as oris-evolution-network v0.4.3