### PR TITLE
docs: docs(P3-04): Architecture Review Board process, CODEOWNERS, RFC template (#306)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @Colin4k1024
+
+/crates/oris-evolution-network/src/ @oris-arb
+/docs/evolution-network-protocol.md @oris-arb
+/docs/runtime-api-contract.json @oris-arb
+/GOVERNANCE.md @oris-arb

--- a/.github/DISCUSSION_TEMPLATE/rfc.md
+++ b/.github/DISCUSSION_TEMPLATE/rfc.md
@@ -1,0 +1,49 @@
+---
+title: "RFC: "
+labels:
+  - rfc
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for Major Architecture Change proposals that require Architecture Review Board review.
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem or opportunity requires this RFC?
+      placeholder: Describe the operational, product, or ecosystem need.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed Change
+      description: What should change and what parts of Oris does it affect?
+      placeholder: Describe the architecture, APIs, protocols, or workflows being proposed.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches were evaluated and why were they not chosen?
+      placeholder: List viable alternatives, tradeoffs, and rejected directions.
+    validations:
+      required: true
+  - type: textarea
+    id: backward-compatibility
+    attributes:
+      label: Backward Compatibility
+      description: What compatibility risks or contract changes should reviewers evaluate?
+      placeholder: Note wire compatibility, API stability, rollout risks, and any breaking behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: migration-plan
+    attributes:
+      label: Migration Plan
+      description: How will users, operators, or downstream integrations adopt this safely?
+      placeholder: Describe rollout steps, feature flags, deprecation windows, and observability needs.
+    validations:
+      required: true

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,6 +20,30 @@ This document describes how the Oris project is maintained and how project decis
   - API stability and migration cost,
   - long-term maintainability.
 
+## Architecture Review Board
+
+The Architecture Review Board (ARB) provides structured review for major architectural changes that can affect protocol compatibility, persistence guarantees, or security posture.
+
+### Charter
+
+- Purpose: review and record decisions for changes that materially affect Oris architecture.
+- Scope: ARB sign-off is required for new persistence backends, changes to the evolution network or runtime API contracts, new gossip or transport layers, and other major architecture changes that can alter downstream integration behavior.
+- Composition: the ARB is made up of rotating maintainer seats so architectural review is shared instead of concentrated in a single maintainer.
+
+### Voting
+
+- Non-breaking architectural changes require a simple majority of recorded ARB votes.
+- Protocol or contract changes require a 2/3 supermajority of recorded ARB votes.
+- Security-sensitive proposals may be vetoed by any ARB reviewer when the proposal introduces unresolved security risk. Vetoes must include the blocking concern in the recorded decision.
+
+### Major Architecture Change Process
+
+- The author opens an RFC discussion using `.github/DISCUSSION_TEMPLATE/rfc.md`.
+- The RFC discussion remains open for a minimum 2-week comment period before a decision is recorded.
+- The ARB reviews the proposal asynchronously and records the vote outcome in the discussion.
+- Approved proposals result in an implementation issue or pull request scoped to the accepted design.
+- Rejected proposals remain documented in the discussion with the reason for rejection.
+
 ## Release policy
 
 - `main` is the active development branch.


### PR DESCRIPTION
Closes #306

## Summary
- add an Architecture Review Board section to GOVERNANCE.md covering charter, voting, and the major architecture change process
- add CODEOWNERS coverage for evolution protocol governance files under @oris-arb
- add a reusable RFC discussion template for architecture proposals

## Validation
- verified diagnostics for GOVERNANCE.md, .github/CODEOWNERS, and .github/DISCUSSION_TEMPLATE/rfc.md
- reviewed git diff for issue-scoped changes only
