### PR TITLE
docs: docs(P3-05): Security vulnerability bounty scope and coordinated disclosure process (#307)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Please do not report security vulnerabilities in public GitHub issues.
 Use one of the following:
 
 1. Preferred: GitHub Security Advisory (private vulnerability report for this repository).
-2. Fallback: contact the repository maintainers privately via GitHub profile contact.
+2. Fallback: contact the maintainers at security@oris-project.example.
 
 When reporting, include:
 
@@ -28,14 +28,54 @@ When reporting, include:
 
 ## What to expect
 
-- Initial triage response target: within 5 business days.
+- Acknowledgment target: within 48 hours.
+- Initial triage target: within 7 days.
 - We may ask for additional details to reproduce.
 - We coordinate disclosure timing and fix release before public details.
+- Our target for fix and coordinated disclosure is within 90 days, or sooner for critical severity issues.
 
 ## Disclosure policy
 
 - We follow responsible disclosure.
 - After a fix is available, maintainers may publish an advisory and remediation guidance.
+
+## Bounty scope
+
+The Oris project uses a recognition-based bounty model for open source security research. Reports with a working proof of concept and clear product impact are prioritized highest.
+
+### In scope: high priority
+
+- Sandbox escape that breaks `crates/oris-sandbox/` process isolation or allows mutation execution to escape the intended boundary.
+- Evolution state deserialization flaws, including remote code execution or equivalent compromise via a malicious `EvolutionEnvelope` or related network payload.
+- Persistence encryption bypass that defeats at-rest protection for Oris-managed state or checkpoint data.
+- Authentication bypass that overrides `ExecutionApiAuthConfig` checks or grants unauthorized access to runtime APIs.
+
+### In scope: standard priority
+
+- SQL injection in runtime repositories or persistence paths maintained by Oris.
+- HMAC bypass in intake webhook signature verification.
+- Privilege escalation in the worker lease system or related task-claim flows.
+
+### Out of scope
+
+- Theoretical issues without a working proof of concept.
+- Vulnerabilities that exist only in third-party dependencies without an Oris-specific amplification path or exploitable integration gap.
+- Best-practice suggestions that do not demonstrate a security impact.
+
+## Coordinated disclosure process
+
+1. Report the issue through GitHub Security Advisories or by emailing security@oris-project.example.
+2. Maintainers acknowledge receipt within 48 hours.
+3. Maintainers complete initial triage within 7 days, including severity assessment and reproduction status.
+4. Maintainers work with the reporter on remediation and target coordinated disclosure within 90 days, or sooner for critical issues.
+
+## Recognition tiers
+
+| Severity | Recognition |
+| --- | --- |
+| Critical (CVSS 9+) | Hall of Fame entry and featured blog post |
+| High (CVSS 7-8.9) | Hall of Fame entry |
+| Medium / Low | Acknowledgment in release notes |
 
 ## Scope notes
 


### PR DESCRIPTION
Closes #307

## Summary
- expand SECURITY.md with explicit in-scope and out-of-scope bounty categories for Oris attack surfaces
- document the coordinated disclosure timeline with 48h acknowledgment, 7d triage, and 90d remediation targets
- add recognition tiers for critical, high, and medium/low reports

## Validation
- verified diagnostics for SECURITY.md
- reviewed git diff for issue-scoped changes only
